### PR TITLE
Update: Improved head and tail types with tests

### DIFF
--- a/test/head.ts
+++ b/test/head.ts
@@ -1,0 +1,25 @@
+import { expectType } from 'tsd';
+import { head } from '../types/head';
+
+// string always return string
+expectType<string>(head('abc'));
+// emptyString still returns type string. this is due to ramda's implementation `''.chartAt(0) => ''`
+expectType<string>(head(''));
+
+// array literals will read the type of the first entry
+expectType<string>(head(['fi', 1, 'fum']));
+// but if the array is typed as an `Array<T> or T[]`, then return type will be `T`
+expectType<string | number | undefined>(head(['fi', 1, 'fum'] as Array<string | number>));
+// empty array literals return never
+expectType<never>(head([]));
+// but if it is typed, it will be `T | undefined`
+expectType<number | undefined>(head([] as number[]));
+// const tuples return the literal type of the first entry
+expectType<10>(head([10, 'ten'] as const));
+expectType<'10'>(head(['10', 10] as const));
+// typed tuples return the underlying type
+expectType<number>(head([10, 'ten'] as [number, string]));
+expectType<string>(head(['10', 10] as [string, number]));
+// typed arrays return `T | undefined`
+expectType<number | string | undefined>(head([10, 'ten'] as Array<number | string>));
+expectType<string | number | undefined>(head(['10', 10] as Array<string | number>));

--- a/test/tail.ts
+++ b/test/tail.ts
@@ -1,0 +1,24 @@
+import { expectType } from 'tsd';
+import { tail } from '../types/tail';
+
+// string always return string
+expectType<string>(tail('abc'));
+// emptyString still returns type string. this is due to `''.chartAt(0) => ''`
+expectType<string>(tail(''));
+
+// array literals will read the first type correctly
+expectType<[number, string]>(tail(['fi', 1, 'fum']));
+// but if the array is typed as an `Array<T> or T[]`, then return type will be `T`
+expectType<Array<string | number>>(tail(['fi', 1, 'fum'] as Array<string | number>));
+// empty array literals return never
+expectType<never>(tail([]));
+// but if it is typed, it will be `number[]`
+expectType<number[]>(tail([] as number[]));
+// single entry tuples return never, since they literally have no tail
+expectType<never>(tail([10] as const));
+// tuples return the example type of the input tuple minus the first entry
+expectType<['10', 10]>(tail([10, '10', 10] as const));
+expectType<[10, '10']>(tail(['10', 10, '10'] as const));
+// typed arrays return the same type
+expectType<Array<number | string>>(tail([10, 'ten'] as Array<number | string>));
+expectType<Array<string | number>>(tail(['10', 10] as Array<string | number>));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,11 @@
   // tsconfig.json supports comments!
   "compilerOptions": {
     "strict": true,
+    "strictNullChecks": true,
     "skipLibCheck": true
   },
   "include": [
-    "types"
+    "types",
   ],
   "exclude": [
     // purposefully leave out `test` folder

--- a/types/head.d.ts
+++ b/types/head.d.ts
@@ -1,3 +1,9 @@
+// string
 export function head(str: string): string;
-export function head(list: readonly []): undefined;
-export function head<T extends any>(list: readonly T[]): T | undefined;
+// empty tuple - purposefully `never`. `head` should never work on tuple type with no length
+export function head(list: readonly []): never;
+// non-empty tuple
+export function head<T1, TRest>(list: readonly [T1, ...TRest[]]): T1;
+// arrays, because these could be empty, they return `T | undefined`
+// this is no different than the tuple form since `T[]` can be empty at runtime
+export function head<T>(list: readonly T[]): T | undefined;

--- a/types/tail.d.ts
+++ b/types/tail.d.ts
@@ -1,2 +1,10 @@
+// string
 export function tail(list: string): string;
-export function tail<T extends any>(list: readonly T[]): T[];
+// empty tuple - purposefully `never, They literally have no tail
+export function tail(list: readonly []): never;
+// length=1 tuples also return `never`. They literally have no tail
+export function tail<T>(list: readonly [T]): never;
+// non-empty tuples and array
+// `infer Rest` only works on types like `readonly [1, '2', 3]` where you will get back `['2', 3]`
+// else, if the type is `string[]`, you'll get back `string[]`
+export function tail<T extends readonly [...any]>(tuple: T): T extends readonly [any, ...infer Rest] ? Rest : T;


### PR DESCRIPTION
This MR updates the types for `head` and `tail` with more accurate typings for tuples and arrays.
No tests that were written in `DefinitelyTyped` fail when I `npm link` the changes over. So this should be completely backwards compatible.