### PR TITLE
Update: forEach

### DIFF
--- a/test/forEach.test.ts
+++ b/test/forEach.test.ts
@@ -1,0 +1,16 @@
+import { expectType } from 'tsd';
+import { __, forEach } from '../es';
+
+const noop = <T>(val: T) => {};
+
+const arr: number[] = [];
+const arrRO: readonly number[] = [];
+
+expectType<number[]>(forEach(noop, arr));
+expectType<readonly number[]>(forEach(noop, arrRO));
+
+expectType<number[]>(forEach(__, arr)(noop));
+expectType<readonly number[]>(forEach(__, arrRO)(noop));
+
+expectType<number[]>(forEach(noop)(arr));
+expectType<readonly number[]>(forEach(noop)(arrRO));

--- a/types/forEach.d.ts
+++ b/types/forEach.d.ts
@@ -1,2 +1,5 @@
-export function forEach<T>(fn: (x: T) => void, list: readonly T[]): T[];
-export function forEach<T>(fn: (x: T) => void): (list: readonly T[]) => T[];
+import { Placeholder } from './util/tools';
+
+export function forEach<T, U extends readonly T[] = readonly T[]>(fn: (x: T) => void, list: U): U;
+export function forEach<U extends readonly any[] = readonly any[]>(__: Placeholder, list: U): (fn: (x: U extends readonly (infer T)[] ? T : never) => void) => U;
+export function forEach<T>(fn: (x: T) => void): <U extends readonly T[]>(list: U) => U;


### PR DESCRIPTION
2 changes, these should be backward compatible

First is adding a generic `U` for the type of `list`. `forEach` passes through the incoming `list`. The previous version did this:

```typescript
const readonlyArr: readonly number[]; = [/*...*/];
const next = forEach(console.log, readonlyArr);
//    ^? number[], NOT readonly number[]
```

By using `<U extends readonly T[]>` and returning `U`, the `readonly number[]` is preserved

Second is adding the `(__: Placeholder, list: U)` variety