### PR TITLE
Draft: Fix: Flip

### DIFF
--- a/types/flip.d.ts
+++ b/types/flip.d.ts
@@ -1,6 +1,9 @@
 import * as _ from 'ts-toolbelt';
 
-export function flip<T, U, TResult>(fn: (arg0: T, arg1: U) => TResult): (arg1: U, arg0?: T) => TResult;
+export function flip<T, U, TResult>(fn: (arg0: T, arg1: U) => TResult): {
+  (arg1: U): (arg0: T) => TResult
+  (arg1: U, arg0: T): TResult
+};
 export function flip<F extends (...args: any) => any, P extends _.F.Parameters<F>>(
   fn: F,
 ): _.F.Curry<(...args: _.T.Merge<[P[1], P[0]], P>) => _.F.Return<F>>;


### PR DESCRIPTION
flip [auto-curries](https://github.com/ramda/ramda/blob/v0.29.0/source/flip.js#L26), typing for 2-arity needed that extra overload in the return

```typescript
// before
flip(lt)(1, 2) // ok
flip(lt)(1,)(2) // error

// after
flip(lt)(1, 2) // ok
flip(lt)(1,)(2) // ok!
```