### PR TITLE
Update: Map

### DIFF
--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -29,9 +29,7 @@ expectType<Record<string, string>>(map(toString, {} as Record<string, number>));
 expectType<Record<string, string>>(map(__, {} as Record<string, number>)(toString));
 expectType<Record<string, string>>(map(toString)({} as Record<string, number>));
 expectType<Record<string, number>>(map(parseInt)({} as Record<string, string>));
-// must set first generic to designate something other that `list: readonly T[]`, needed when passing return function to another function
-expectType<Record<string, string>>(pipe(map<'o', unknown, string>(toString))({} as Record<string, number>));
-expectType<Record<string, number>>(pipe(map<'o', string, number>(parseInt))({} as Record<string, string>));
+// no `pipe` support yet for objects
 
 // make sure that `fn` is a union of the types for an object
 type Foobar = {
@@ -60,9 +58,7 @@ expectType<TestFunctorMap<number>>(map(__, {} as TestFunctorMap<string>)(parseIn
 expectType<TestFunctorMap<string>>(map(__, {} as TestFunctorMap<number>)(toString));
 expectType<TestFunctorMap<string>>(map(toString)({} as TestFunctorMap<number>));
 expectType<TestFunctorMap<number>>(map(parseInt)({} as TestFunctorMap<string>));
-// must set first generic to designate something other that `list: readonly T[]`, needed when passing return function to another function
-expectType<TestFunctorMap<string>>(pipe(map<'f', unknown, string>(toString))({} as TestFunctorMap<number>));
-expectType<TestFunctorMap<number>>(pipe(map<'f', string, number>(parseInt))({} as TestFunctorMap<string>));
+// no `pipe` support yet for Functor
 
 
 // fantasy-land specific
@@ -77,6 +73,4 @@ expectType<TestFunctorFantasyLand<number>>(map(__, {} as TestFunctorFantasyLand<
 expectType<TestFunctorFantasyLand<string>>(map(__, {} as TestFunctorFantasyLand<number>)(toString));
 expectType<TestFunctorFantasyLand<number>>(map(parseInt)({} as TestFunctorFantasyLand<string>));
 expectType<TestFunctorFantasyLand<string>>(map(toString)({} as TestFunctorFantasyLand<number>));
-// must set first generic to designate something other that `list: readonly T[]`, needed when passing return function to another function
-expectType<TestFunctorFantasyLand<number>>(pipe(map<'fl', string, number>(parseInt))({} as TestFunctorFantasyLand<string>));
-expectType<TestFunctorFantasyLand<string>>(pipe(map<'fl', unknown, string>(toString))({} as TestFunctorFantasyLand<number>));
+// no `pipe` support yet for FunctorFantasyLand

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -1,0 +1,37 @@
+import { expectType, expectAssignable } from 'tsd';
+import { __, FunctorMap, map, toString } from '../es';
+
+const arr: number[] = [];
+const arrRO: readonly number[] = [];
+
+// array
+expectType<string[]>(map(toString, arr));
+expectType<string[]>(map(toString, arrRO));
+
+expectType<string[]>(map(__, arr)(toString));
+expectType<string[]>(map(__, arrRO)(toString));
+
+expectType<string[]>(map(toString)(arr));
+expectType<string[]>(map(toString)(arrRO));
+
+
+// object
+expectType<Record<string, string>>(map(toString, {} as Record<string, number>));
+expectType<Record<string, string>>(map(__, {} as Record<string, number>)(toString));
+expectType<Record<string, string>>(map(toString)({} as Record<string, number>));
+
+
+// functor
+type TestFunctorMap<A> = {
+  map: <B>(fn: (a: A) => B) => TestFunctorMap<B>;
+};
+
+expectType<FunctorMap<string>>(map(toString, {} as TestFunctorMap<number>));
+expectAssignable<TestFunctorMap<string>>(map(toString, {} as TestFunctorMap<number>));
+
+type TestFunctorFantasyLand<A> = {
+  ['fantasy-land/map']: <B>(fn: (a: A) => B) => TestFunctorFantasyLand<B>;
+};
+
+expectType<TestFunctorFantasyLand<string>>(map(__, {} as TestFunctorFantasyLand<number>)(toString));
+expectType<TestFunctorFantasyLand<string>>(map(toString)({} as TestFunctorFantasyLand<number>));

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -1,5 +1,5 @@
 import { expectType, expectAssignable } from 'tsd';
-import { __, FunctorMap, map, toString, pipe, compose } from '../es';
+import { __, FunctorMap, map, toString, pipe } from '../es';
 
 const arr: number[] = [];
 const arrRO: readonly number[] = [];
@@ -14,7 +14,13 @@ expectType<string[]>(map(__, arrRO)(toString));
 expectType<string[]>(map(toString)(arr));
 expectType<string[]>(map(toString)(arrRO));
 
-// expectType<(list: readonly number[]) => string>(pipe(map(toString)));
+// when the first argument of the fn passed to map is not a generic, the type is preserved when passed into pipe
+expectType<(list: readonly string[]) => number[]>(pipe(map(parseInt)));
+// because first argument of `toString` is a generic, running through `pipe` gives us `(list: readonly unknown[])`
+// this is a limitation of typescript
+expectType<(list: readonly unknown[]) => string[]>(pipe(map(toString)));
+// that only mapped is map is the first in line
+expectType<(list: readonly string[]) => string[]>(pipe(map(parseInt), map(toString)));
 
 
 // object

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -1,4 +1,4 @@
-import { expectType, expectAssignable } from 'tsd';
+import { expectType } from 'tsd';
 import { __, FunctorMap, map, toString, pipe } from '../es';
 
 const arr: number[] = [];
@@ -26,7 +26,8 @@ expectType<(list: readonly string[]) => string[]>(pipe(map(parseInt), map(toStri
 // object
 expectType<Record<string, string>>(map(toString, {} as Record<string, number>));
 expectType<Record<string, string>>(map(__, {} as Record<string, number>)(toString));
-expectType<Record<string, string>>(map(toString)({} as Record<string, number>));
+// must set first generic to designate something other that `list: readonly T[]`
+expectType<Record<string, string>>(map<'o'>(toString)({} as Record<string, number>));
 
 
 // functor
@@ -35,11 +36,15 @@ type TestFunctorMap<A> = {
 };
 
 expectType<FunctorMap<string>>(map(toString, {} as TestFunctorMap<number>));
-expectAssignable<TestFunctorMap<string>>(map(toString, {} as TestFunctorMap<number>));
+expectType<TestFunctorMap<string>>(map(__, {} as TestFunctorMap<number>)(toString));
+// must set first generic to designate something other that `list: readonly T[]`
+expectType<TestFunctorMap<string>>(map<'f'>(toString)({} as TestFunctorMap<number>));
 
 type TestFunctorFantasyLand<A> = {
   ['fantasy-land/map']: <B>(fn: (a: A) => B) => TestFunctorFantasyLand<B>;
 };
 
 expectType<TestFunctorFantasyLand<string>>(map(__, {} as TestFunctorFantasyLand<number>)(toString));
-expectType<TestFunctorFantasyLand<string>>(map(toString)({} as TestFunctorFantasyLand<number>));
+expectType<TestFunctorFantasyLand<string>>(map(toString, {} as TestFunctorFantasyLand<number>));
+// must set first generic to designate something other that `list: readonly T[]`
+expectType<TestFunctorFantasyLand<string>>(map<'fl'>(toString)({} as TestFunctorFantasyLand<number>));

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -61,6 +61,8 @@ expectType<TestFunctorMap<string>>(map(__, {} as TestFunctorMap<number>)(toStrin
 expectType<TestFunctorMap<string>>(map<'f', unknown, string>(toString)({} as TestFunctorMap<number>));
 expectType<TestFunctorMap<number>>(map<'f', string, number>(parseInt)({} as TestFunctorMap<string>));
 
+
+// fantasy-land specific
 type TestFunctorFantasyLand<A> = {
   ['fantasy-land/map']: <B>(fn: (a: A) => B) => TestFunctorFantasyLand<B>;
 };

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -1,5 +1,5 @@
 import { expectType, expectAssignable } from 'tsd';
-import { __, FunctorMap, map, toString } from '../es';
+import { __, FunctorMap, map, toString, pipe, compose } from '../es';
 
 const arr: number[] = [];
 const arrRO: readonly number[] = [];
@@ -13,6 +13,8 @@ expectType<string[]>(map(__, arrRO)(toString));
 
 expectType<string[]>(map(toString)(arr));
 expectType<string[]>(map(toString)(arrRO));
+
+// expectType<(list: readonly number[]) => string>(pipe(map(toString)));
 
 
 // object

--- a/test/map.test.ts
+++ b/test/map.test.ts
@@ -27,9 +27,11 @@ expectType<(list: readonly number[]) => number[]>(pipe(map<number, number>(ident
 // object
 expectType<Record<string, string>>(map(toString, {} as Record<string, number>));
 expectType<Record<string, string>>(map(__, {} as Record<string, number>)(toString));
-// for other than `list: readonly T[]`, must set generics
-expectType<Record<string, string>>(map<'o', unknown, string>(toString)({} as Record<string, number>));
-expectType<Record<string, number>>(map<'o', string, number>(parseInt)({} as Record<string, string>));
+expectType<Record<string, string>>(map(toString)({} as Record<string, number>));
+expectType<Record<string, number>>(map(parseInt)({} as Record<string, string>));
+// must set first generic to designate something other that `list: readonly T[]`, needed when passing return function to another function
+expectType<Record<string, string>>(pipe(map<'o', unknown, string>(toString))({} as Record<string, number>));
+expectType<Record<string, number>>(pipe(map<'o', string, number>(parseInt))({} as Record<string, string>));
 
 // make sure that `fn` is a union of the types for an object
 type Foobar = {
@@ -46,7 +48,6 @@ expectError(map(strFunc, {} as Foobar));
 expectType<Record<keyof Foobar, string>>(map(unionFunc, {} as Foobar));
 
 
-
 // functor
 type TestFunctorMap<A> = {
   map: <B>(fn: (a: A) => B) => TestFunctorMap<B>;
@@ -57,9 +58,11 @@ expectType<TestFunctorMap<number>>(map(parseInt, {} as TestFunctorMap<string>));
 expectType<TestFunctorMap<string>>(map(toString, {} as TestFunctorMap<number>));
 expectType<TestFunctorMap<number>>(map(__, {} as TestFunctorMap<string>)(parseInt));
 expectType<TestFunctorMap<string>>(map(__, {} as TestFunctorMap<number>)(toString));
-// must set first generic to designate something other that `list: readonly T[]`
-expectType<TestFunctorMap<string>>(map<'f', unknown, string>(toString)({} as TestFunctorMap<number>));
-expectType<TestFunctorMap<number>>(map<'f', string, number>(parseInt)({} as TestFunctorMap<string>));
+expectType<TestFunctorMap<string>>(map(toString)({} as TestFunctorMap<number>));
+expectType<TestFunctorMap<number>>(map(parseInt)({} as TestFunctorMap<string>));
+// must set first generic to designate something other that `list: readonly T[]`, needed when passing return function to another function
+expectType<TestFunctorMap<string>>(pipe(map<'f', unknown, string>(toString))({} as TestFunctorMap<number>));
+expectType<TestFunctorMap<number>>(pipe(map<'f', string, number>(parseInt))({} as TestFunctorMap<string>));
 
 
 // fantasy-land specific
@@ -72,6 +75,8 @@ expectType<TestFunctorFantasyLand<number>>(map(parseInt, {} as TestFunctorFantas
 expectType<TestFunctorFantasyLand<string>>(map(toString, {} as TestFunctorFantasyLand<number>));
 expectType<TestFunctorFantasyLand<number>>(map(__, {} as TestFunctorFantasyLand<string>)(parseInt));
 expectType<TestFunctorFantasyLand<string>>(map(__, {} as TestFunctorFantasyLand<number>)(toString));
-// must set first generic to designate something other that `list: readonly T[]`
-expectType<TestFunctorFantasyLand<number>>(map<'fl', string, number>(parseInt)({} as TestFunctorFantasyLand<string>));
-expectType<TestFunctorFantasyLand<string>>(map<'fl', unknown, string>(toString)({} as TestFunctorFantasyLand<number>));
+expectType<TestFunctorFantasyLand<number>>(map(parseInt)({} as TestFunctorFantasyLand<string>));
+expectType<TestFunctorFantasyLand<string>>(map(toString)({} as TestFunctorFantasyLand<number>));
+// must set first generic to designate something other that `list: readonly T[]`, needed when passing return function to another function
+expectType<TestFunctorFantasyLand<number>>(pipe(map<'fl', string, number>(parseInt))({} as TestFunctorFantasyLand<string>));
+expectType<TestFunctorFantasyLand<string>>(pipe(map<'fl', unknown, string>(toString))({} as TestFunctorFantasyLand<number>));

--- a/types/map.README.md
+++ b/types/map.README.md
@@ -14,7 +14,7 @@ This means that you cannot do this
 ```typescript
 map(parseInt)(['1', '2']) // ok
 map(parseInt)({ foo: '1', bar :'2' }) // errors
-map(praseInt)(Just('1')) // errors
+map(parseInt)(Just('1')) // errors
 ```
 
 To fix this, a single function returns an overload of functions

--- a/types/map.README.md
+++ b/types/map.README.md
@@ -3,88 +3,132 @@
 Lets start by looking at the previous definition
 
 ```typescript
-
-```
-
-There is very unusual overload for `map(fn) => (c) => U`
-
-The first overload is pretty self explanatory
-```typescript
 export function map<T, U>(fn: (x: T) => U): (list: readonly T[]) => U[];
+export function map<T, U>(fn: (x: T[keyof T & keyof U] | ValueOfUnion<T>) => U[keyof T & keyof U]): (list: T) => U;
+// used in functors
+export function map<T, U>(fn: (x: T) => U): (obj: Functor<T>) => Functor<U>;
 ```
 
-This is for 90% of use-cases, when `c` is `list: readonly T[]`.
-
-The second needs some explanation
+This is not the correct way to write types for a function that returns overloads. Typescript will never reach the second 2 definitions.
+This means that you cannot do this
 ```typescript
+map(parseInt)(['1', '2']) // ok
+map(parseInt)({ foo: '1', bar :'2' }) // errors
+map(praseInt)(Just('1')) // errors
+```
+
+To fix this, a single function returns an overload of functions
+```typescript
+export function map<T, U>(fn (x: T) => U): {
+  (list: readonly T[]): U[];
+  <O extends Record<PropertyKey, T>(obj: O): Record<keyof O, U>;
+  (functor: Functor<T>): Functor<U>;
+};
+```
+
+Now the above situation works!
+
+```typescript
+map(parseInt)(['1', '2']) // ok => [1, 2]
+map(parseInt)({ foo: '1', bar :'2' }) // ok => { foo: 1, bar: 2 }
+map(praseInt)(Just('1')) // ok => Just(1)
+```
+
+There is however another problem. And that is when you pass `map(fn)` as an argument to another function, like `compose`
+
+```typescript
+compose(map(parseInt));
+```
+
+The problem with the above is that typescript specifically takes [the last defined overload](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) when a function is passed as an argument in this way.
+
+This means that `map(parseInt)` above will return whatever is defined last. So in the case above, it is `(functor: Functor<T>) => Functor<U>`.
+```typescript
+compose(map(parseInt))(['1', '2']); // error
+compose(map(parseInt))({ foo: '1', bar: '2' }); // error
+compose(map(parseInt))(new Just('1')); // ok
+```
+
+So now we're back at the original problem, but in reverse. Lets fix that
+
+```typescript
+export function map<T, U>(fn: (x: T) => U): {
+  (list: readonly T[]): U[];
+  (obj: Functor<T>): Functor<U>;
+  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
+  (list: readonly T[]): U[];
+};
+```
+
+`(list: readonly T[]): U[];` is purposely both the first and the last overload here.
+
+```typescript
+// if we only have (list: readonly T[]): U[]; as the first, `map(fn)(list)` would fail, because its expecting a Record<>
+map(parseInt) // => <O extends Record<PropertyKey, T>>(dict: O) => Record<keyof O, U>
+
+// but if we only have it as the last, `map(fn)(list)` falls into the `FunctorMap` variety when `map(parseInt)` is passed to `compose` first
+compose(map(parseInt))(['1', '2']) // => FunctorMap<number> !! not number[] !!
+
+// but when we have both
+map(parseInt) // => (list: readonly string[]) => number[]
+compose(map(parseInt))(['1', '2']) // => [1, 2]
+```
+
+But if `compose(map(parseInt))` now works with `list: readonly T[]`, how can we get it to work for objects and Functors?
+
+To solve this, we can use a fairly unknown typescript technique where we can "select" what the returned function is supposed to take as an argument
+
+```typescript
+export function map<T, U>(fn: (x: T) => U): {
+  (list: readonly T[]): U[];
+  (obj: Functor<T>): Functor<U>;
+  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
+  (list: readonly T[]): U[];
+};
 export function map<H extends 'o' | 'f' | 'fl', T, U>(fn: (x: T) => U): {
   // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
   // in these circumstances `a` will auto pic the correct overload
-  (obj: FunctorMap<T>): FunctorMap<U>;
-  (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
+  (obj: Functor<T>): Functor<U>;
   <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
   // that doesn't work when passing the function as an argument to another function
   // this fallback takes over in that case, and lets you use the generic helper `H` to set what the expected param type needs to be
   <O extends Record<PropertyKey, T>>(functor: {
     'o': O;
-    'f': FunctorMap<T>;
-    'fl': FunctorFantasyLand<T>;
+    'f': Functor<T>;
   }[H extends infer H_ ? H_ : never]): {
     'o': Record<keyof O, U>;
-    'f': FunctorMap<U>;
-    'fl': FunctorFantasyLand<U>;
+    'f': Functor<U>;
   }[H extends infer H_ ? H_ : never];
 };
 ```
 
-This is here specifically for the use-case when you pass the result of `map(fn)` to another function, such as `compose` or `pipe`
-```typescript
-compose(map(fn))
-```
-
-Typescript specifically takes [the last defined overload](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) when a function is passed as an argument in this way
-
-What that means is that if the definition was only this:
-```typescript
-export function map<T, U>(fn: (x: T) => U): {
-  (obj: FunctorMap<T>): FunctorMap<U>;
-  (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
-  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
-}
-```
-Then `compose(map(fn))` would return a function that only excepted `(dict: O)`. Typescript looses the ability to correctly select the overload in the same way if you were to simply call the function after, eg `map(fn)(o)` or `map(fn)(functor)`
-
-The solution for this is to add a special final overload
-```typescript
-  export function map<H extends 'o' | 'f' | 'fl', T, U>(fn: (x: T) => U): {
-  // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
-  // in these circumstances `a` will auto pic the correct overload
-  (obj: FunctorMap<T>): FunctorMap<U>;
-  (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
-  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
-  // that doesn't work when passing the function as an argument to another function
-  // this fallback takes over in that case, and lets you use the generic helper `H` to set what the expected param type needs to be
-  <O extends Record<PropertyKey, T>>(functor: {
-    'o': O;
-    'f': FunctorMap<T>;
-    'fl': FunctorFantasyLand<T>;
-  }[H extends infer H_ ? H_ : never]): {
-    'o': Record<keyof O, U>;
-    'f': FunctorMap<U>;
-    'fl': FunctorFantasyLand<U>;
-  }[H extends infer H_ ? H_ : never];
-};
-```
-
-What this does is is allow the user to set what `c` is in `map(fn) => (c) => U` via the generic
+The second overload has 3 generics, the first generic can be set to either `'o'` or `'f'` to force the return function's argument type to be one of the other options.
 
 ```typescript
-// need `c` to be `Record<T, U>`?
+// when you need the return funcs argument to be an object
 map<'o', string, number>(parseInt)({ foo: '1', bar: '2' });
-// a functor?
-map<'f', T, U>(parseInt)(new Just('1')); // Just#map
-// a fantasy-land functor
-map<'fl', T, U>(parseInt)(new Just('1')); // Just#['fantasy-land/map']
+// or a functor
+map<'f', string, number>(parseInt)(Just('1')); // Just#map
 ```
 
-Note: there is no way to automatically do both `#map` and `#['fantasy-land/map']` such that the return has the correct one. It must be manually selected
+The one downside with this is it makes you set the other generics as well, but that's a small caveat
+
+Now we're able to have all of the following, which covers all supported use cases by `ramda`!
+
+```typescript
+map(parseInt, ['1', '2']); // => [1, 2]
+map(parseInt, { foo: '1', bar: '2' }); // => { foo: 1, bar: 2 }
+map(parseInt, Just('1')); // => Just(1)
+
+map(__, ['1', '2'])(parseInt); // => [1, 2]
+map(__, { foo: '1', bar: '2' })(parseInt); // => { foo: 1, bar: 2 }
+map(__, Just('1'))(parseInt); // => Just(1)
+
+map(parseInt)(['1', '2']); // => [1, 2]
+map(parseInt)({ foo: '1', bar: '2' }); // => { foo: 1, bar: 2 }
+map(parseInt)(Just('1')); // => Just(1)
+
+compose(map(parseInt))(['1', '2']); // => [1, 2]
+compose(map<'o', string, number>(parseInt))({ foo: '1', bar: '2' }); // => { foo: 1, bar: 2 }
+compose(map<'f', string, number>(parseInt))(Just('1')); // => Just(1)
+```

--- a/types/map.README.md
+++ b/types/map.README.md
@@ -1,0 +1,90 @@
+# the map(fn) => (list) => U overload
+
+Lets start by looking at the previous definition
+
+```typescript
+
+```
+
+There is very unusual overload for `map(fn) => (c) => U`
+
+The first overload is pretty self explanatory
+```typescript
+export function map<T, U>(fn: (x: T) => U): (list: readonly T[]) => U[];
+```
+
+This is for 90% of use-cases, when `c` is `list: readonly T[]`.
+
+The second needs some explanation
+```typescript
+export function map<H extends 'o' | 'f' | 'fl', T, U>(fn: (x: T) => U): {
+  // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
+  // in these circumstances `a` will auto pic the correct overload
+  (obj: FunctorMap<T>): FunctorMap<U>;
+  (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
+  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
+  // that doesn't work when passing the function as an argument to another function
+  // this fallback takes over in that case, and lets you use the generic helper `H` to set what the expected param type needs to be
+  <O extends Record<PropertyKey, T>>(functor: {
+    'o': O;
+    'f': FunctorMap<T>;
+    'fl': FunctorFantasyLand<T>;
+  }[H extends infer H_ ? H_ : never]): {
+    'o': Record<keyof O, U>;
+    'f': FunctorMap<U>;
+    'fl': FunctorFantasyLand<U>;
+  }[H extends infer H_ ? H_ : never];
+};
+```
+
+This is here specifically for the use-case when you pass the result of `map(fn)` to another function, such as `compose` or `pipe`
+```typescript
+compose(map(fn))
+```
+
+Typescript specifically takes [the last defined overload](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html) when a function is passed as an argument in this way
+
+What that means is that if the definition was only this:
+```typescript
+export function map<T, U>(fn: (x: T) => U): {
+  (obj: FunctorMap<T>): FunctorMap<U>;
+  (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
+  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
+}
+```
+Then `compose(map(fn))` would return a function that only excepted `(dict: O)`. Typescript looses the ability to correctly select the overload in the same way if you were to simply call the function after, eg `map(fn)(o)` or `map(fn)(functor)`
+
+The solution for this is to add a special final overload
+```typescript
+  export function map<H extends 'o' | 'f' | 'fl', T, U>(fn: (x: T) => U): {
+  // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
+  // in these circumstances `a` will auto pic the correct overload
+  (obj: FunctorMap<T>): FunctorMap<U>;
+  (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
+  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
+  // that doesn't work when passing the function as an argument to another function
+  // this fallback takes over in that case, and lets you use the generic helper `H` to set what the expected param type needs to be
+  <O extends Record<PropertyKey, T>>(functor: {
+    'o': O;
+    'f': FunctorMap<T>;
+    'fl': FunctorFantasyLand<T>;
+  }[H extends infer H_ ? H_ : never]): {
+    'o': Record<keyof O, U>;
+    'f': FunctorMap<U>;
+    'fl': FunctorFantasyLand<U>;
+  }[H extends infer H_ ? H_ : never];
+};
+```
+
+What this does is is allow the user to set what `c` is in `map(fn) => (c) => U` via the generic
+
+```typescript
+// need `c` to be `Record<T, U>`?
+map<'o', string, number>(parseInt)({ foo: '1', bar: '2' });
+// a functor?
+map<'f', T, U>(parseInt)(new Just('1')); // Just#map
+// a fantasy-land functor
+map<'fl', T, U>(parseInt)(new Just('1')); // Just#['fantasy-land/map']
+```
+
+Note: there is no way to automatically do both `#map` and `#['fantasy-land/map']` such that the return has the correct one. It must be manually selected

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -11,22 +11,7 @@ export function map<T, U>(fn: (x: T) => U): {
   // it also needs to be here when you pass map as an argument to a function, eg `compose(map(fn))`
   (list: readonly T[]): U[];
 };
-// see readme for details
-export function map<H extends 'o' | 'f' | 'fl', T, U>(fn: (x: T) => U): {
-  // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
-  // in these circumstances `a` will auto pic the correct overload
-  // that doesn't work when passing the function as an argument to another function
-  // this fallback takes over in that case, and lets you use the generic helper `H` to set what the expected param type needs to be
-  <O extends Record<PropertyKey, T>>(functor: {
-    'o': O;
-    'f': FunctorMap<T>;
-    'fl': FunctorFantasyLand<T>;
-  }[H extends infer H_ ? H_ : never]): {
-    'o': Record<keyof O, U>;
-    'f': FunctorMap<U>;
-    'fl': FunctorFantasyLand<U>;
-  }[H extends infer H_ ? H_ : never];
-};
+
 // map(__, list)
 export function map<T>(__: Placeholder, list: readonly T[]): <U>(fn: (x: T) => U) => U[];
 export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (a: A) => B) => FunctorFantasyLand<B>;

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -41,4 +41,3 @@ export function map<T, U>(fn: (x: T) => U, obj: FunctorMap<T>): FunctorMap<U>;
 export function map<O extends object, U>(fn: (x: ValueOfUnion<O>) => U, dict: O): Record<keyof O, U>;
 // it also needs to be here when you pass map as an argument to a function, eg `flip(map)`
 export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
-

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -1,7 +1,16 @@
 import { FunctorMap, FunctorFantasyLand, Placeholder, ValueOfUnion } from './util/tools';
 
 // map(fn)
-export function map<T, U>(fn: (x: T) => U): (list: readonly T[]) => U[];
+export function map<T, U>(fn: (x: T) => U): {
+  // first and last def are the same and are here on purpose
+  // the list variant needs to come before the FunctorMap ones, because `T[]` is a `FunctorMap<T>`
+  (list: readonly T[]): U[];
+  (functor: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
+  (functor: FunctorMap<T>): FunctorMap<U>;
+  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
+  // it also needs to be here when you pass map as an argument to a function, eg `compose(map(fn))`
+  (list: readonly T[]): U[];
+};
 // see readme for details
 export function map<H extends 'o' | 'f' | 'fl', T, U>(fn: (x: T) => U): {
   // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -1,33 +1,31 @@
 import { FunctorMap, FunctorFantasyLand, Placeholder, ValueOfUnion } from './util/tools';
 
 // map(fn)
+export function map<T, U>(fn: (x: T) => U): (list: readonly T[]) => U[];
 // see readme for details
-export function map<H extends 'list' | 'obj' | 'functor' | 'fantasyland' = 'list', T = any, U = any>(fn: (x: T) => U): {
+export function map<H extends 'o' | 'f' | 'fl', T = any, U = any>(fn: (x: T) => U): {
   // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
   // in these circumstances `a` will auto pic the correct overload
-  (list: readonly T[]): U[];
   (obj: FunctorMap<T>): FunctorMap<U>;
   (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
   <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
   // that doesn't when passing `map` as a prop to another function like `pipe` or `compose`
   // this fallback takes over in those cases, and lets you use the generic helper `H` to set what the expected param type needs to be
   <O extends Record<PropertyKey, T>>(functor: {
-    'list': readonly T[];
-    'functor': FunctorMap<T>;
-    'fantasyland': FunctorFantasyLand<T>;
-    'obj': O;
+    'o': O;
+    'f': FunctorMap<T>;
+    'fl': FunctorFantasyLand<T>;
   }[H extends infer H_ ? H_ : never]): {
-    'list': U[];
-    'obj': Record<keyof O, U>;
-    'functor': FunctorMap<U>;
-    'fantasyland': FunctorFantasyLand<U>;
+    'o': Record<keyof O, U>;
+    'f': FunctorMap<U>;
+    'fl': FunctorFantasyLand<U>;
   }[H extends infer H_ ? H_ : never];
 };
 // map(__, list)
 export function map<T>(__: Placeholder, list: readonly T[]): <U>(fn: (x: T) => U) => U[];
-export function map<O extends object>(__: Placeholder, dict: O): <U>(fn: (x: ValueOfUnion<O>) => U) => Record<keyof O, U>;
 export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (a: A) => B) => FunctorFantasyLand<B>;
 export function map<A>(__: Placeholder, obj: FunctorMap<A>): <B>(fn: (a: A) => B) => FunctorMap<B>;
+export function map<O extends object>(__: Placeholder, dict: O): <U>(fn: (x: ValueOfUnion<O>) => U) => Record<keyof O, U>;
 // map(fn, list)
 // first and last def are the same and are here on purpose
 // the list variant needs to come before the FunctorMap ones, because `T[]` is a `FunctorMap<T>`

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -6,9 +6,6 @@ export function map<T, U>(fn: (x: T) => U): (list: readonly T[]) => U[];
 export function map<H extends 'o' | 'f' | 'fl', T, U>(fn: (x: T) => U): {
   // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
   // in these circumstances `a` will auto pic the correct overload
-  (obj: FunctorMap<T>): FunctorMap<U>;
-  (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
-  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
   // that doesn't work when passing the function as an argument to another function
   // this fallback takes over in that case, and lets you use the generic helper `H` to set what the expected param type needs to be
   <O extends Record<PropertyKey, T>>(functor: {
@@ -35,6 +32,4 @@ export function map<T, U>(fn: (x: T) => U, obj: FunctorMap<T>): FunctorMap<U>;
 export function map<O extends object, U>(fn: (x: ValueOfUnion<O>) => U, dict: O): Record<keyof O, U>;
 // it also needs to be here when you pass map as an argument to a function, eg `flip(map)`
 export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
-
-
 

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -1,16 +1,8 @@
 import { FunctorMap, FunctorFantasyLand, Placeholder, ValueOfUnion } from './util/tools';
 
-export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
-export function map<T, U>(fn: (x: T) => U, obj: FunctorMap<T>): FunctorMap<U>;
-export function map<T, U>(fn: (x: T) => U, obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
-export function map<O extends object, U>(fn: (x: ValueOfUnion<O>) => U, dict: O): Record<keyof O, U>;
-
-export function map<T>(__: Placeholder, list: readonly T[]): <U>(fn: (x: T) => U) => U[];
-export function map<A>(__: Placeholder, obj: FunctorMap<A>): <B>(fn: (a: A) => B) => FunctorMap<B>;
-export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (a: A) => B) => FunctorFantasyLand<B>;
-export function map<O extends object>(__: Placeholder, dict: O): <U>(fn: (x: ValueOfUnion<O>) => U) => Record<keyof O, U>;
-
-function map<H extends 'list' | 'obj' | 'functor' | 'fantasyland' = 'list', T = any, U = any>(fn: (x: T) => U): {
+// map(fn)
+// see readme for details
+export function map<H extends 'list' | 'obj' | 'functor' | 'fantasyland' = 'list', T = any, U = any>(fn: (x: T) => U): {
   // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
   // in these circumstances `a` will auto pic the correct overload
   (list: readonly T[]): U[];
@@ -31,3 +23,20 @@ function map<H extends 'list' | 'obj' | 'functor' | 'fantasyland' = 'list', T = 
     'fantasyland': FunctorFantasyLand<U>;
   }[H extends infer H_ ? H_ : never];
 };
+// map(__, list)
+export function map<T>(__: Placeholder, list: readonly T[]): <U>(fn: (x: T) => U) => U[];
+export function map<O extends object>(__: Placeholder, dict: O): <U>(fn: (x: ValueOfUnion<O>) => U) => Record<keyof O, U>;
+export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (a: A) => B) => FunctorFantasyLand<B>;
+export function map<A>(__: Placeholder, obj: FunctorMap<A>): <B>(fn: (a: A) => B) => FunctorMap<B>;
+// map(fn, list)
+// first and last def are the same and are here on purpose
+// the list variant needs to come before the FunctorMap ones, because `T[]` is a `FunctorMap<T>`
+export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
+export function map<T, U>(fn: (x: T) => U, obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
+export function map<T, U>(fn: (x: T) => U, obj: FunctorMap<T>): FunctorMap<U>;
+export function map<O extends object, U>(fn: (x: ValueOfUnion<O>) => U, dict: O): Record<keyof O, U>;
+// it also needs to be here when you pass map as an argument to a function, eg `flip(map)`
+export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
+
+
+

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -1,9 +1,18 @@
-import { ValueOfUnion, Functor } from './util/tools';
+import { FunctorMap, FunctorFantasyLand, Placeholder, ValueOfUnion } from './util/tools';
 
 export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
-export function map<T, U>(fn: (x: T) => U): (list: readonly T[]) => U[];
-export function map<T, U>(fn: (x: T[keyof T & keyof U] | ValueOfUnion<T>) => U[keyof T & keyof U], list: T): U;
-export function map<T, U>(fn: (x: T[keyof T & keyof U] | ValueOfUnion<T>) => U[keyof T & keyof U]): (list: T) => U;
-// used in functors
-export function map<T, U>(fn: (x: T) => U, obj: Functor<T>): Functor<U>;
-export function map<T, U>(fn: (x: T) => U): (obj: Functor<T>) => Functor<U>;
+export function map<T, U>(fn: (x: T) => U, obj: FunctorMap<T>): FunctorMap<U>;
+export function map<T, U>(fn: (x: T) => U, obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
+export function map<O extends object, U>(fn: (x: ValueOfUnion<O>) => U, dict: O): Record<keyof O, U>;
+
+export function map<T>(__: Placeholder, list: readonly T[]): <U>(fn: (x: T) => U) => U[];
+export function map<A>(__: Placeholder, obj: FunctorMap<A>): <B>(fn: (a: A) => B) => FunctorMap<B>;
+export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (a: A) => B) => FunctorFantasyLand<B>;
+export function map<O extends object>(__: Placeholder, dict: O): <U>(fn: (x: ValueOfUnion<O>) => U) => Record<keyof O, U>;
+
+export function map<T, U>(fn: (x: T) => U): {
+  (list: readonly T[]): U[];
+  (obj: FunctorMap<T>): FunctorMap<U>;
+  (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
+  <O extends Record<string, T>>(dict: O): Record<keyof O, U>;
+};

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -10,9 +10,24 @@ export function map<A>(__: Placeholder, obj: FunctorMap<A>): <B>(fn: (a: A) => B
 export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (a: A) => B) => FunctorFantasyLand<B>;
 export function map<O extends object>(__: Placeholder, dict: O): <U>(fn: (x: ValueOfUnion<O>) => U) => Record<keyof O, U>;
 
-export function map<T, U>(fn: (x: T) => U): {
+function map<H extends 'list' | 'obj' | 'functor' | 'fantasyland' = 'list', T = any, U = any>(fn: (x: T) => U): {
+  // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
+  // in these circumstances `a` will auto pic the correct overload
   (list: readonly T[]): U[];
   (obj: FunctorMap<T>): FunctorMap<U>;
   (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
-  <O extends Record<string, T>>(dict: O): Record<keyof O, U>;
+  <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
+  // that doesn't when passing `map` as a prop to another function like `pipe` or `compose`
+  // this fallback takes over in those cases, and lets you use the generic helper `H` to set what the expected param type needs to be
+  <O extends Record<PropertyKey, T>>(functor: {
+    'list': readonly T[];
+    'functor': FunctorMap<T>;
+    'fantasyland': FunctorFantasyLand<T>;
+    'obj': O;
+  }[H extends infer H_ ? H_ : never]): {
+    'list': U[];
+    'obj': Record<keyof O, U>;
+    'functor': FunctorMap<U>;
+    'fantasyland': FunctorFantasyLand<U>;
+  }[H extends infer H_ ? H_ : never];
 };

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -3,14 +3,14 @@ import { FunctorMap, FunctorFantasyLand, Placeholder, ValueOfUnion } from './uti
 // map(fn)
 export function map<T, U>(fn: (x: T) => U): (list: readonly T[]) => U[];
 // see readme for details
-export function map<H extends 'o' | 'f' | 'fl', T = any, U = any>(fn: (x: T) => U): {
+export function map<H extends 'o' | 'f' | 'fl', T, U>(fn: (x: T) => U): {
   // the first 4 overloads work for `map(fn)(a)` or `const mapF = map(fn); mapF(a)` usages
   // in these circumstances `a` will auto pic the correct overload
   (obj: FunctorMap<T>): FunctorMap<U>;
   (obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
   <O extends Record<PropertyKey, T>>(dict: O): Record<keyof O, U>;
-  // that doesn't when passing `map` as a prop to another function like `pipe` or `compose`
-  // this fallback takes over in those cases, and lets you use the generic helper `H` to set what the expected param type needs to be
+  // that doesn't work when passing the function as an argument to another function
+  // this fallback takes over in that case, and lets you use the generic helper `H` to set what the expected param type needs to be
   <O extends Record<PropertyKey, T>>(functor: {
     'o': O;
     'f': FunctorMap<T>;

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -108,6 +108,20 @@ export type Functor<A> =
     | { map: <B>(fn: (a: A) => B) => Functor<B>; [key: string]: any };
 
 /**
+ * A Functor - a simple type representing a Functor that used `map` is the method prop name
+ */
+export type FunctorMap<A> = {
+  map<B>(fn: (a: A) => B): FunctorMap<B>;
+};
+
+/**
+ * A FantasyLand Functor - a simple type representing a Functor wiih the fantasy-land specific prop name
+ */
+export type FunctorFantasyLand<A> = {
+  ['fantasy-land/map']<B>(fn: (a: A) => B): FunctorFantasyLand<B>;
+};
+
+/**
  * R.any dispatches to `.any` of the second argument, if present.
  * This type infers the type of the first argument of that method and returns it
  */


### PR DESCRIPTION
This MR updates `map` to support mapping over an array, an object, or a Functor.

Caveat: due to typescript limitations, when passing `map(a)` into another function as a variable, typescript defaults to the last overload, this means that while the following works:
```typescript
map(toString)([1, 2, 3]); // ok
map(toString)({ a: 1, b: 2, c: 3 }); // ok
```
Passing to `pipe` only supports arrays
```typescript
pipe(map(toString))([1, 2, 3]); // ok
pipe(map(toString))({ a: 1, b: 2, c: 3 }); // error
```

I have a few ideas for how to fix the above caveat, and I will address it in a new issue