### PR TITLE
Fix: `pathEq` Argument order change for 0.29.0 release

### DIFF
--- a/types/pathEq.d.ts
+++ b/types/pathEq.d.ts
@@ -1,6 +1,8 @@
-import * as _ from 'ts-toolbelt';
 import { Path } from './util/tools';
 
-export function pathEq(path: Path, val: any, obj: any): boolean;
-export function pathEq(path: Path, val: any): (obj: any) => boolean;
-export function pathEq(path: Path): _.F.Curry<(a: any, b: any) => boolean>;
+export function pathEq(val: any, path: Path, obj: any): boolean;
+export function pathEq(val: any, path: Path): (obj: any) => boolean;
+export function pathEq(val: any): {
+  (path: Path): (obj: any) => boolean;
+  (path: Path, obj: any): boolean;
+};


### PR DESCRIPTION
Fix the argument order