### PR TITLE
Updating defaultTo type definitions

### DIFF
--- a/test/defaultTo.test.ts
+++ b/test/defaultTo.test.ts
@@ -1,10 +1,12 @@
 import { expectType } from 'tsd';
-import { defaultTo } from '../es';
+import { defaultTo, __ } from '../es';
 
 expectType<'fallback'>(defaultTo('fallback', undefined));
 expectType<'fallback'>(defaultTo('fallback', null));
 expectType<string>(defaultTo('fallback')(undefined));
 expectType<string>(defaultTo('fallback')(null));
+expectType<'fallback'>(defaultTo(__, undefined)('fallback'));
+expectType<'fallback'>(defaultTo(__, null)('fallback'));
 
 expectType<'string value'>(defaultTo('fallback', 'string value'));
 expectType<'string value'>(defaultTo('fallback')('string value'));
@@ -13,25 +15,35 @@ expectType<0>(defaultTo(0, undefined));
 expectType<0>(defaultTo(0, null));
 expectType<number>(defaultTo(0)(undefined));
 expectType<number>(defaultTo(0)(null));
+expectType<0>(defaultTo(__, undefined)(0));
+expectType<0>(defaultTo(__, null)(0));
 
 expectType<2>(defaultTo(0, 2));
 expectType<2>(defaultTo(0)(2));
+expectType<number>(defaultTo(__, 2)(0));
 
 expectType<'two'>(defaultTo(0, 'two'));
 expectType<'two'>(defaultTo(0)('two'));
+expectType<string>(defaultTo(__, 'two')(0));
 expectType<2>(defaultTo('zero', 2));
 expectType<2>(defaultTo('zero')(2));
+expectType<number>(defaultTo(__, 2)('zero'));
 
 const stringOrUndefined = Math.random() < 0.5 ? Math.random().toString(32) : undefined;
 expectType<0 | string>(defaultTo(0, stringOrUndefined));
 expectType<number | string>(defaultTo(0)(stringOrUndefined));
+expectType<0 | string>(defaultTo(__, stringOrUndefined)(0));
 const stringOrNull = Math.random() < 0.5 ? Math.random().toString(32) : null;
 expectType<0 | string>(defaultTo(0, stringOrNull));
 expectType<number | string>(defaultTo(0)(stringOrNull));
+expectType<0 | string>(defaultTo(__, stringOrNull)(0));
+
 
 const numberOrUndefined = Math.random() < 0.5 ? Math.random() : undefined;
 expectType<'fallback' | number>(defaultTo('fallback', numberOrUndefined));
 expectType<string | number>(defaultTo('fallback')(numberOrUndefined));
+expectType<'fallback' | number>(defaultTo(__, numberOrUndefined)('fallback'));
 const numberOrNull = Math.random() < 0.5 ? Math.random() : null;
 expectType<'fallback' | number>(defaultTo('fallback', numberOrNull));
 expectType<string | number>(defaultTo('fallback')(numberOrNull));
+expectType<'fallback' | number>(defaultTo(__, numberOrNull)('fallback'));

--- a/test/defaultTo.test.ts
+++ b/test/defaultTo.test.ts
@@ -1,13 +1,13 @@
 import { expectType } from 'tsd';
 import { defaultTo } from '../es';
 
-expectType<string>(defaultTo('no value', undefined));
-expectType<string>(defaultTo('no value', null));
-expectType<string>(defaultTo('no value')(undefined));
-expectType<string>(defaultTo('no value')(null));
+expectType<string>(defaultTo('default value', undefined));
+expectType<string>(defaultTo('default value', null));
+expectType<string>(defaultTo('default value')(undefined));
+expectType<string>(defaultTo('default value')(null));
 
-expectType<string>(defaultTo('no value', 'string value'));
-expectType<string>(defaultTo('no value')('string value'));
+expectType<string>(defaultTo('default value', 'string value'));
+expectType<string>(defaultTo('default value')('string value'));
 
 expectType<number>(defaultTo(0, undefined));
 expectType<number>(defaultTo(0, null));
@@ -22,16 +22,16 @@ expectType<string>(defaultTo(0)('two'));
 expectType<number>(defaultTo('zero', 2));
 expectType<number>(defaultTo('zero')(2));
 
-
-const stringOrUndefined = (() => Math.random() < 0.5 ? Math.random().toString(32) : undefined)();
+const stringOrUndefined = Math.random() < 0.5 ? Math.random().toString(32) : undefined;
 expectType<number | string>(defaultTo(0, stringOrUndefined));
-const stringOrNull = (() => Math.random() < 0.5 ? Math.random().toString(32) : undefined)();
+expectType<number | string>(defaultTo(0)(stringOrUndefined));
+const stringOrNull = Math.random() < 0.5 ? Math.random().toString(32) : null;
 expectType<number | string>(defaultTo(0, stringOrNull));
-
+expectType<number | string>(defaultTo(0)(stringOrNull));
 
 const numberOrUndefined = Math.random() < 0.5 ? Math.random() : undefined;
-expectType<string | number>(defaultTo('no value', numberOrUndefined));
+expectType<string | number>(defaultTo('default value', numberOrUndefined));
+expectType<string | number>(defaultTo('default value')(numberOrUndefined));
 const numberOrNull = Math.random() < 0.5 ? Math.random() : null;
-expectType<string | number>(defaultTo('no value', numberOrNull));
-
-
+expectType<string | number>(defaultTo('default value', numberOrNull));
+expectType<string | number>(defaultTo('default value')(numberOrNull));

--- a/test/defaultTo.test.ts
+++ b/test/defaultTo.test.ts
@@ -1,37 +1,37 @@
 import { expectType } from 'tsd';
 import { defaultTo } from '../es';
 
-expectType<string>(defaultTo('default value', undefined));
-expectType<string>(defaultTo('default value', null));
-expectType<string>(defaultTo('default value')(undefined));
-expectType<string>(defaultTo('default value')(null));
+expectType<'fallback'>(defaultTo('fallback', undefined));
+expectType<'fallback'>(defaultTo('fallback', null));
+expectType<string>(defaultTo('fallback')(undefined));
+expectType<string>(defaultTo('fallback')(null));
 
-expectType<string>(defaultTo('default value', 'string value'));
-expectType<string>(defaultTo('default value')('string value'));
+expectType<'string value'>(defaultTo('fallback', 'string value'));
+expectType<'string value'>(defaultTo('fallback')('string value'));
 
-expectType<number>(defaultTo(0, undefined));
-expectType<number>(defaultTo(0, null));
+expectType<0>(defaultTo(0, undefined));
+expectType<0>(defaultTo(0, null));
 expectType<number>(defaultTo(0)(undefined));
 expectType<number>(defaultTo(0)(null));
 
-expectType<number>(defaultTo(0, 2));
-expectType<number>(defaultTo(0)(2));
+expectType<2>(defaultTo(0, 2));
+expectType<2>(defaultTo(0)(2));
 
-expectType<string>(defaultTo(0, 'two'));
-expectType<string>(defaultTo(0)('two'));
-expectType<number>(defaultTo('zero', 2));
-expectType<number>(defaultTo('zero')(2));
+expectType<'two'>(defaultTo(0, 'two'));
+expectType<'two'>(defaultTo(0)('two'));
+expectType<2>(defaultTo('zero', 2));
+expectType<2>(defaultTo('zero')(2));
 
 const stringOrUndefined = Math.random() < 0.5 ? Math.random().toString(32) : undefined;
-expectType<number | string>(defaultTo(0, stringOrUndefined));
+expectType<0 | string>(defaultTo(0, stringOrUndefined));
 expectType<number | string>(defaultTo(0)(stringOrUndefined));
 const stringOrNull = Math.random() < 0.5 ? Math.random().toString(32) : null;
-expectType<number | string>(defaultTo(0, stringOrNull));
+expectType<0 | string>(defaultTo(0, stringOrNull));
 expectType<number | string>(defaultTo(0)(stringOrNull));
 
 const numberOrUndefined = Math.random() < 0.5 ? Math.random() : undefined;
-expectType<string | number>(defaultTo('default value', numberOrUndefined));
-expectType<string | number>(defaultTo('default value')(numberOrUndefined));
+expectType<'fallback' | number>(defaultTo('fallback', numberOrUndefined));
+expectType<string | number>(defaultTo('fallback')(numberOrUndefined));
 const numberOrNull = Math.random() < 0.5 ? Math.random() : null;
-expectType<string | number>(defaultTo('default value', numberOrNull));
-expectType<string | number>(defaultTo('default value')(numberOrNull));
+expectType<'fallback' | number>(defaultTo('fallback', numberOrNull));
+expectType<string | number>(defaultTo('fallback')(numberOrNull));

--- a/test/defaultTo.test.ts
+++ b/test/defaultTo.test.ts
@@ -1,0 +1,37 @@
+import { expectType } from 'tsd';
+import { defaultTo } from '../es';
+
+expectType<string>(defaultTo('no value', undefined));
+expectType<string>(defaultTo('no value', null));
+expectType<string>(defaultTo('no value')(undefined));
+expectType<string>(defaultTo('no value')(null));
+
+expectType<string>(defaultTo('no value', 'string value'));
+expectType<string>(defaultTo('no value')('string value'));
+
+expectType<number>(defaultTo(0, undefined));
+expectType<number>(defaultTo(0, null));
+expectType<number>(defaultTo(0)(undefined));
+expectType<number>(defaultTo(0)(null));
+
+expectType<number>(defaultTo(0, 2));
+expectType<number>(defaultTo(0)(2));
+
+expectType<string>(defaultTo(0, 'two'));
+expectType<string>(defaultTo(0)('two'));
+expectType<number>(defaultTo('zero', 2));
+expectType<number>(defaultTo('zero')(2));
+
+
+const stringOrUndefined = (() => Math.random() < 0.5 ? Math.random().toString(32) : undefined)();
+expectType<number | string>(defaultTo(0, stringOrUndefined));
+const stringOrNull = (() => Math.random() < 0.5 ? Math.random().toString(32) : undefined)();
+expectType<number | string>(defaultTo(0, stringOrNull));
+
+
+const numberOrUndefined = Math.random() < 0.5 ? Math.random() : undefined;
+expectType<string | number>(defaultTo('no value', numberOrUndefined));
+const numberOrNull = Math.random() < 0.5 ? Math.random() : null;
+expectType<string | number>(defaultTo('no value', numberOrNull));
+
+

--- a/types/defaultTo.d.ts
+++ b/types/defaultTo.d.ts
@@ -1,4 +1,5 @@
-import { DefaultTo } from './util/tools';
+import { DefaultTo, Placeholder } from './util/tools';
 
-export function defaultTo<Fallback, Value>(a: Fallback, b: Value): DefaultTo<Fallback, Value>;
 export function defaultTo<Fallback>(a: Fallback): <Value>(b: Value) => DefaultTo<Fallback, Value>;
+export function defaultTo<Value>(__: Placeholder, b: Value): <Fallback>(a: Fallback) => DefaultTo<Fallback, Value>;
+export function defaultTo<Fallback, Value>(a: Fallback, b: Value): DefaultTo<Fallback, Value>;

--- a/types/defaultTo.d.ts
+++ b/types/defaultTo.d.ts
@@ -1,2 +1,15 @@
-export function defaultTo<T, U>(a: T, b: U | null | undefined): T | U;
-export function defaultTo<T>(a: T): <U>(b: U | null | undefined) => T | U;
+
+export function defaultTo<Default, Value>(a: Default, b: Value): (Value extends (null | undefined) ? Default | NonNullable<Value> : Value);
+export function defaultTo<Default>(a: Default): <Value>(b: Value) => (Value extends (null | undefined) ? Default | NonNullable<Value> : Value);
+
+
+type DefaultTo<Default, Value> = (Value extends (null | undefined) ? Default | NonNullable<Value> : Value);
+
+type ShouldBeString1 = DefaultTo<string, undefined>;
+type ShouldBeString2 = DefaultTo<string, null>;
+type ShouldBeNumber = DefaultTo<string, number>;
+type ShouldBeStringOrNumber1 = DefaultTo<string, number | undefined>;
+type ShouldBeStringOrNumber2 = DefaultTo<string, number | null>;
+
+
+

--- a/types/defaultTo.d.ts
+++ b/types/defaultTo.d.ts
@@ -1,12 +1,13 @@
 
-export function defaultTo<Default, Value>(a: Default, b: Value): (Value extends (null | undefined) ? Default | Exclude<Value, null | undefined> : Value);
-export function defaultTo<Default>(a: Default): <Value>(b: Value) => (Value extends (null | undefined) ? Default | Exclude<Value, null | undefined> : Value);
+export function defaultTo<Fallback, Value>(a: Fallback, b: Value): (Value extends (null | undefined) ? Fallback | Exclude<Value, null | undefined> : Value);
+export function defaultTo<Fallback>(a: Fallback): <Value>(b: Value) => (Value extends (null | undefined) ? Fallback | Exclude<Value, null | undefined> : Value);
 
 
-type DefaultTo<Default, Value> = (Value extends (null | undefined) ? Default | Exclude<Value, null | undefined> : Value);
+type DefaultTo<Fallback, Value> = (Value extends (null | undefined) ? Fallback | Exclude<Value, null | undefined> : Value);
 
 type ShouldBeString1 = DefaultTo<string, undefined>;
 type ShouldBeString2 = DefaultTo<string, null>;
+type ShouldBeString3 = DefaultTo<number, string>;
 type ShouldBeNumber = DefaultTo<string, number>;
 type ShouldBeStringOrNumber1 = DefaultTo<string, number | undefined>;
 type ShouldBeStringOrNumber2 = DefaultTo<string, number | null>;

--- a/types/defaultTo.d.ts
+++ b/types/defaultTo.d.ts
@@ -1,13 +1,4 @@
+import { DefaultTo } from './util/tools';
 
-export function defaultTo<Fallback, Value>(a: Fallback, b: Value): (Value extends (null | undefined) ? Fallback | Exclude<Value, null | undefined> : Value);
-export function defaultTo<Fallback>(a: Fallback): <Value>(b: Value) => (Value extends (null | undefined) ? Fallback | Exclude<Value, null | undefined> : Value);
-
-
-type DefaultTo<Fallback, Value> = (Value extends (null | undefined) ? Fallback | Exclude<Value, null | undefined> : Value);
-
-type ShouldBeString1 = DefaultTo<string, undefined>;
-type ShouldBeString2 = DefaultTo<string, null>;
-type ShouldBeString3 = DefaultTo<number, string>;
-type ShouldBeNumber = DefaultTo<string, number>;
-type ShouldBeStringOrNumber1 = DefaultTo<string, number | undefined>;
-type ShouldBeStringOrNumber2 = DefaultTo<string, number | null>;
+export function defaultTo<Fallback, Value>(a: Fallback, b: Value): DefaultTo<Fallback, Value>;
+export function defaultTo<Fallback>(a: Fallback): <Value>(b: Value) => DefaultTo<Fallback, Value>;

--- a/types/defaultTo.d.ts
+++ b/types/defaultTo.d.ts
@@ -1,15 +1,12 @@
 
-export function defaultTo<Default, Value>(a: Default, b: Value): (Value extends (null | undefined) ? Default | NonNullable<Value> : Value);
-export function defaultTo<Default>(a: Default): <Value>(b: Value) => (Value extends (null | undefined) ? Default | NonNullable<Value> : Value);
+export function defaultTo<Default, Value>(a: Default, b: Value): (Value extends (null | undefined) ? Default | Exclude<Value, null | undefined> : Value);
+export function defaultTo<Default>(a: Default): <Value>(b: Value) => (Value extends (null | undefined) ? Default | Exclude<Value, null | undefined> : Value);
 
 
-type DefaultTo<Default, Value> = (Value extends (null | undefined) ? Default | NonNullable<Value> : Value);
+type DefaultTo<Default, Value> = (Value extends (null | undefined) ? Default | Exclude<Value, null | undefined> : Value);
 
 type ShouldBeString1 = DefaultTo<string, undefined>;
 type ShouldBeString2 = DefaultTo<string, null>;
 type ShouldBeNumber = DefaultTo<string, number>;
 type ShouldBeStringOrNumber1 = DefaultTo<string, number | undefined>;
 type ShouldBeStringOrNumber2 = DefaultTo<string, number | null>;
-
-
-

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -31,6 +31,12 @@ export type CondPair<T extends any[], R> = [(...val: T) => boolean, (...val: T) 
 export type CondPairTypeguard<T, TFiltered extends T, R> = [(value: T) => value is TFiltered, (value: TFiltered) => R];
 
 /**
+ * A conditional type to use with default values. (defaultTo, propOr, etc)
+ * <created by @lax4mike>
+ */
+export type DefaultTo<Fallback, Value> = (Value extends (null | undefined) ? Fallback | Exclude<Value, null | undefined> : Value);
+
+/**
  * Represents all objects evolvable with Evolver E
  * @param E
  */


### PR DESCRIPTION
See discussion here: https://github.com/ramda/types/issues/29

The current type definitions for `defaultTo` are incorrect in that the following test passes when it shouldn't:
```typescript
expectType<string | undefined>(R.defaultTo('default value', undefined)); // << incorrect
```

This PR updates the `defaultTo` type definitions such that the following tests pass:
```typescript
expectType<string>(defaultTo('default value', undefined));

expectType<string>(defaultTo(0, 'two'));
expectType<number>(defaultTo('zero', 2));

const numberOrUndefined = Math.random() < 0.5 ? 0 : undefined;
expectType<string | number>(defaultTo('default value', numberOrUndefined));
```