### PR TITLE
Update: isNotNil use built-in NonNullable

### DIFF
--- a/types/isNotNil.d.ts
+++ b/types/isNotNil.d.ts
@@ -1,3 +1,1 @@
-import * as _ from 'ts-toolbelt';
-
 export function isNotNil<T>(value: T): value is NonNullable<T>;

--- a/types/isNotNil.d.ts
+++ b/types/isNotNil.d.ts
@@ -1,3 +1,3 @@
 import * as _ from 'ts-toolbelt';
 
-export function isNotNil<T>(value: T): value is _.U.NonNullable<T>;
+export function isNotNil<T>(value: T): value is NonNullable<T>;


### PR DESCRIPTION
Use `NonNullable` so type guard is recognized as boolean by tools like [typescript-eslint/strict-boolean-expressions](https://typescript-eslint.io/rules/strict-boolean-expressions)

**Before**

![image](https://github.com/ramda/types/assets/58871222/47751ca2-8198-408d-a6b8-991cd7aac7a5)

**After**

![image](https://github.com/ramda/types/assets/58871222/c9d5cd11-c356-498b-97d6-d8b9f06e89d2)
