### PR TITLE
Breaking: prop

### DIFF
--- a/test/prop.test.ts
+++ b/test/prop.test.ts
@@ -1,0 +1,42 @@
+import { expectError, expectType } from 'tsd';
+
+import { __, prop } from '../es';
+
+type Foo = {
+  a: string;
+  b: number;
+};
+
+// prop(key)(obj)
+// support objects
+expectType<string>(prop('a')({} as Foo));
+expectType<number>(prop('b')({} as Foo));
+// reject keys unknown in either direction
+expectError(prop('c')({} as Foo));
+expectError(prop('a')({ c: 'error' }));
+// support arrays
+expectType<number>(prop(0)([1, 2, 3, 4]));
+// all numbers work as keys, no guarantee it will return a value
+expectType<number>(prop(10)([1, 2, 3, 4]));
+
+// prop(__, obj)(key)
+expectType<string>(prop(__, {} as Foo)('a'));
+expectType<number>(prop(__, {} as Foo)('b'));
+// reject keys unknown in either direction
+expectError(prop(__, {} as Foo)('c'));
+expectError(prop(__, { c: 'error' })('a'));
+// support arrays
+expectType<number>(prop(__, [1, 2, 3, 4])(0));
+// all numbers work as keys, no guarantee it will return a value
+expectType<number>(prop(__, [1, 2, 3, 4])(10));
+
+// prop(prop, obj)
+expectType<string>(prop('a', {} as Foo));
+expectType<number>(prop('b', {} as Foo));
+// reject keys unknown in either direction
+expectError(prop('c', {} as Foo));
+expectError(prop('a', { c: 'error' }));
+// support arrays
+expectType<number>(prop(0, [1, 2, 3, 4]));
+// all numbers work as keys, no guarantee it will return a value
+expectType<number>(prop(10, [1, 2, 3, 4]));

--- a/test/prop.test.ts
+++ b/test/prop.test.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd';
 
-import { __, prop } from '../es';
+import { __, find, pipe, prop } from '../es';
 
 type Foo = {
   a: string;
@@ -40,3 +40,23 @@ expectError(prop('a', { c: 'error' }));
 expectType<number>(prop(0, [1, 2, 3, 4]));
 // all numbers work as keys, no guarantee it will return a value
 expectType<number>(prop(10, [1, 2, 3, 4]));
+
+//
+// testing and example of unions with `undefined`
+//
+
+type Todo = { description: string; isDone: boolean };
+
+const todos: Todo[] = [/* ... */];
+
+// the find return `Todo | undefined`, so `prop` errors
+expectError(pipe(
+  find((todo: Todo) => todo.isDone),
+  prop('description')
+));
+
+// add in non-null assertion to have it pass
+expectType<string>(pipe(
+  (todos: Todo[]) => find(todo => todo.isDone, todos)!,
+  prop('description')
+)(todos));

--- a/test/prop.test.ts
+++ b/test/prop.test.ts
@@ -7,11 +7,16 @@ type Foo = {
   b: number;
 };
 
+const foo: Foo = { a: '1', b: 2 };
+
 // prop(key)(obj)
 // support objects
+foo.a;
 expectType<string>(prop('a')({} as Foo));
 expectType<number>(prop('b')({} as Foo));
 // reject keys unknown in either direction
+// @ts-expect-error
+foo.c;
 expectError(prop('c')({} as Foo));
 expectError(prop('a')({ c: 'error' }));
 

--- a/test/prop.test.ts
+++ b/test/prop.test.ts
@@ -9,28 +9,22 @@ type Foo = {
 
 const foo: Foo = { a: '1', b: 2 };
 
-// prop(key)(obj)
 // support objects
 foo.a;
 expectType<string>(prop('a')({} as Foo));
 expectType<number>(prop('b')({} as Foo));
+expectType<string>(prop(__, {} as Foo)('a'));
+expectType<number>(prop(__, {} as Foo)('b'));
+expectType<string>(prop('a', {} as Foo));
+expectType<number>(prop('b', {} as Foo));
+
 // reject keys unknown in either direction
 // @ts-expect-error
 foo.c;
 expectError(prop('c')({} as Foo));
 expectError(prop('a')({ c: 'error' }));
-
-// prop(__, obj)(key)
-expectType<string>(prop(__, {} as Foo)('a'));
-expectType<number>(prop(__, {} as Foo)('b'));
-// reject keys unknown in either direction
 expectError(prop(__, {} as Foo)('c'));
 expectError(prop(__, { c: 'error' })('a'));
-
-// prop(prop, obj)
-expectType<string>(prop('a', {} as Foo));
-expectType<number>(prop('b', {} as Foo));
-// reject keys unknown in either direction
 expectError(prop('c', {} as Foo));
 expectError(prop('a', { c: 'error' }));
 

--- a/test/prop.test.ts
+++ b/test/prop.test.ts
@@ -1,6 +1,6 @@
 import { expectError, expectType } from 'tsd';
 
-import { __, find, pipe, prop } from '../es';
+import { __, find, isNil, pipe, prop, tap } from '../es';
 
 type Foo = {
   a: string;
@@ -14,10 +14,6 @@ expectType<number>(prop('b')({} as Foo));
 // reject keys unknown in either direction
 expectError(prop('c')({} as Foo));
 expectError(prop('a')({ c: 'error' }));
-// support arrays
-expectType<number>(prop(0)([1, 2, 3, 4]));
-// all numbers work as keys, no guarantee it will return a value
-expectType<number>(prop(10)([1, 2, 3, 4]));
 
 // prop(__, obj)(key)
 expectType<string>(prop(__, {} as Foo)('a'));
@@ -25,10 +21,6 @@ expectType<number>(prop(__, {} as Foo)('b'));
 // reject keys unknown in either direction
 expectError(prop(__, {} as Foo)('c'));
 expectError(prop(__, { c: 'error' })('a'));
-// support arrays
-expectType<number>(prop(__, [1, 2, 3, 4])(0));
-// all numbers work as keys, no guarantee it will return a value
-expectType<number>(prop(__, [1, 2, 3, 4])(10));
 
 // prop(prop, obj)
 expectType<string>(prop('a', {} as Foo));
@@ -36,10 +28,6 @@ expectType<number>(prop('b', {} as Foo));
 // reject keys unknown in either direction
 expectError(prop('c', {} as Foo));
 expectError(prop('a', { c: 'error' }));
-// support arrays
-expectType<number>(prop(0, [1, 2, 3, 4]));
-// all numbers work as keys, no guarantee it will return a value
-expectType<number>(prop(10, [1, 2, 3, 4]));
 
 //
 // testing and example of unions with `undefined`
@@ -58,5 +46,14 @@ expectError(pipe(
 // add in non-null assertion to have it pass
 expectType<string>(pipe(
   (todos: Todo[]) => find(todo => todo.isDone, todos)!,
+  prop('description')
+)(todos));
+
+// or `asserts` with a `tap`
+expectType<string>(pipe(
+  (todos: Todo[]) => find(todo => todo.isDone, todos)!,
+  tap((x: Todo): asserts x => {
+    if (isNil(x)) { throw new Error("Couldn't find Todo"); }
+  }),
   prop('description')
 )(todos));

--- a/test/prop.test.ts
+++ b/test/prop.test.ts
@@ -34,6 +34,12 @@ expectType<number>(prop('b', {} as Foo));
 expectError(prop('c', {} as Foo));
 expectError(prop('a', { c: 'error' }));
 
+// `Record` always works because of the nature of record
+expectType<number>(prop('foo', {} as Record<string, number>));
+expectType<number>(prop('bar', {} as Record<string, number>));
+expectType<number>(prop('biz', {} as Record<string, number>));
+expectType<number>(prop('baz', {} as Record<string, number>));
+
 //
 // testing and example of unions with `undefined`
 //

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -3,7 +3,7 @@ import { Placeholder } from './util/tools';
 
 // prop(key)(obj)
 export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends any[] | Record<K, any>>(obj: U) => U extends (infer T)[] ? T : U extends Record<K, any> ? U[K] : never;
-// prop(__, obj))key
+// prop(__, obj)(key)
 export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(prop: K) => U[K];
 // prop(key, obj)
 export function prop<K extends keyof U, U>(prop: K extends Placeholder ? never : K, obj: U): U[K];

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -2,7 +2,7 @@
 import { Placeholder } from './util/tools';
 
 // prop(key)(obj)
-export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends Record<K, any>>(obj: U) => U[K];
+export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends any[] | Record<K, any>>(obj: U) => U extends (infer T)[] ? T : U extends Record<K, any> ? U[K] : never;
 // prop(__, obj))key
 export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(prop: K) => U[K];
 // prop(key, obj)

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -6,4 +6,4 @@ export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never 
 // prop(__, obj)(key)
 export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(prop: K) => U[K];
 // prop(key, obj)
-export function prop<K extends keyof U, U>(prop: K extends Placeholder ? never : K, obj: U): U[K];
+export function prop<K extends keyof U, U>(prop: K, obj: U): U[K];

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -1,12 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Placeholder, Prop } from './util/tools';
+import { Placeholder } from './util/tools';
 
-export function prop<_, T>(__: Placeholder, value: T): {
-  <P extends keyof Exclude<T, undefined>>(p: P): Prop<T, P>;
-  <P extends keyof never>(p: P): Prop<T, P>;
-};
-export function prop<V>(__: Placeholder, value: unknown): (p: keyof never) => V;
-export function prop<_, P extends keyof never, T>(p: P, value: T): Prop<T, P>;
-export function prop<V>(p: keyof never, value: unknown): V;
-export function prop<_, P extends keyof never>(p: P): <T>(value: T) => Prop<T, P>;
-export function prop<V>(p: keyof never): (value: unknown) => V;
+// most common use case, when key is known on the object
+export function prop<K extends keyof U, U>(key: K, obj: U): U[K];
+// placeholder
+export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(key: K) => U[K];
+// curried
+export function prop<K extends PropertyKey>(key: K): <U>(obj: U) => U extends Record<K, infer T> ? T : never;

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -1,18 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Placeholder } from './util/tools';
 
-// placeholder
-export function prop<U>(__: Placeholder, obj: U): {
-  // key known
-  <_, K extends keyof U>(key: K): U[K];
-  // key unknown, return value settable in generic
-  <V>(key: PropertyKey): V | undefined;
-};
-// most common use case, when key is known on the object
-export function prop<K extends keyof U, U>(key: K, obj: U): U[K];
-// if the key is not known, fall back to this, which defaultly returns unknown, but the generic allows for user to set the return value
-export function prop<V>(key: PropertyKey, obj: unknown): V | undefined;
-// key known, `_` is to keep typescript from getting confused when trying to use the type below
-export function prop<_, K extends PropertyKey>(key: K): <U>(obj: U) => U extends (Record<K, infer T> | Array<infer T>) ? T : never;
-// key unknown
-export function prop<V>(key: PropertyKey): (obj: unknown) => V | unknown;
+// prop(key)(obj)
+export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends Record<K, any>>(obj: U) => U[K];
+// prop(__, obj))key
+export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(prop: K) => U[K];
+// prop(key, obj)
+export function prop<K extends keyof U, U>(prop: K extends Placeholder ? never : K, obj: U): U[K];

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -1,9 +1,18 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Placeholder } from './util/tools';
 
+// placeholder
+export function prop<U>(__: Placeholder, obj: U): {
+  // key known
+  <_, K extends keyof U>(key: K): U[K];
+  // key unknown, return value settable in generic
+  <V>(key: PropertyKey): V | undefined;
+};
 // most common use case, when key is known on the object
 export function prop<K extends keyof U, U>(key: K, obj: U): U[K];
-// placeholder
-export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(key: K) => U[K];
-// curried
-export function prop<K extends PropertyKey>(key: K): <U>(obj: U) => U extends Record<K, infer T> ? T : never;
+// if the key is not known, fall back to this, which defaultly returns unknown, but the generic allows for user to set the return value
+export function prop<V>(key: PropertyKey, obj: unknown): V | undefined;
+// key known, `_` is to keep typescript from getting confused when trying to use the type below
+export function prop<_, K extends PropertyKey>(key: K): <U>(obj: U) => U extends (Record<K, infer T> | Array<infer T>) ? T : never;
+// key unknown
+export function prop<V>(key: PropertyKey): (obj: unknown) => V | unknown;

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -2,7 +2,7 @@
 import { Placeholder } from './util/tools';
 
 // prop(key)(obj)
-export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends Record<K, any>>(obj: U) => U[K];
+export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends Record<K, unknown>>(obj: U) => U[K];
 // prop(__, obj)(key)
 export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(prop: K) => U[K];
 // prop(key, obj)

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -2,7 +2,7 @@
 import { Placeholder } from './util/tools';
 
 // prop(key)(obj)
-export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends any[] | Record<K, any>>(obj: U) => U extends (infer T)[] ? T : U extends Record<K, any> ? U[K] : never;
+export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends Record<K, any>>(obj: U) => U[K];
 // prop(__, obj)(key)
 export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(prop: K) => U[K];
 // prop(key, obj)


### PR DESCRIPTION
This update of the types for `prop` corrects what I consider a major flaw in the previous typing

The previous version used a utility type `Prop` that is defined in `util/tools.d.ts` What it essentially did was ignore unions with `undefined`, such that

```typescript
({ a: string } | undefined)['a'] // error
Prop<{ a: string } | undefined, 'a'> // string
```

This effectively side-steps the type safety that typescript gives us

Consider the following:
```typescript
type Todo = { description: string; isDone: boolean };

const todos: Todo[] = [/* ... */];

const firstActiveTodo = todo.find(todo => !todo.isDone);
//    ^? Todo | undefined

// the previous implementation of `prop` worked this way
const description = prop('description', firstActiveTodo);
//    ^? string

// the new implementation will type error here because `'description'` is not prop of `undefined`
const description = prop('description', firstActiveTodo);
```

The above type safety is a key part of typescript and it is important to force an opt-out off it for convenience

There are 3 ways to get around this. First would be to have `strictNullChecks: false` in your tsconfig. This will make functions such as `.find()` not return with the `undefined` union.

The other 2 would be done in code:
```typescript
// check for undefined
if (isNotNil(firstActiveTodo) {
  // ^^ this narrows the type from `Todo | undefined` to `Todo`
  return prop('description', firstActiveTodo)
}

// or for a less safe way, use the non-null assertion operator
const description = prop('description', firstActiveTodo!);
//    ^? string
```

Using the `!` non-null assertion operator is effectively an inline way to opt-in to the previous behavior

When using `compose`/`pipe`, users may have to make updates such as this:
```typescript
const findFirstDescription = pipe(
  find((todo: Todo) => todo.isDone),
  prop('description') // used to work, now errors
);

const findFirstDescription = pipe(
  (todos: Todo[]) => find(todo => todo.isDone, todos)!,
  prop('description') // works because of non-null assertion above
);
```

While I am calling this change `Breaking`. We have to keep our minor version locked with `ramda`. So it will be a regular release