### PR TITLE
fix(groupBy): return Partial Record

### DIFF
--- a/test/groupBy.test.ts
+++ b/test/groupBy.test.ts
@@ -1,4 +1,6 @@
-import { groupBy } from '../es';
+import { groupBy, __ } from '../es';
+
+// returns optional arrays for the groups
 
 const byGrade = groupBy((student: { score: number; name: string }) => {
   const score = student.score;
@@ -14,3 +16,11 @@ const grouped = byGrade(students);
 (grouped.C ?? []).length;
 // @ts-expect-error
 grouped.C.length;
+
+// accepts a placeholder and later specifying the grouping function
+
+const byGrade2 = groupBy(__, students);
+byGrade2((student: { score: number; name: string }) => {
+  const score = student.score;
+  return score < 65 ? 'F' : score < 70 ? 'D' : score < 80 ? 'C' : score < 90 ? 'B' : 'A';
+});

--- a/test/groupBy.test.ts
+++ b/test/groupBy.test.ts
@@ -1,3 +1,4 @@
+import { expectType } from 'tsd';
 import { groupBy, __ } from '../es';
 
 // returns optional arrays for the groups
@@ -13,6 +14,7 @@ const students = [
 ];
 
 const grouped = byGrade(students);
+expectType<{ score: number; name: string }[] | undefined>(grouped.C);
 (grouped.C ?? []).length;
 // @ts-expect-error
 grouped.C.length;
@@ -20,7 +22,8 @@ grouped.C.length;
 // accepts a placeholder and later specifying the grouping function
 
 const byGrade2 = groupBy(__, students);
-byGrade2((student: { score: number; name: string }) => {
+const grouped2 = byGrade2((student: { score: number; name: string }) => {
   const score = student.score;
   return score < 65 ? 'F' : score < 70 ? 'D' : score < 80 ? 'C' : score < 90 ? 'B' : 'A';
 });
+expectType<{ score: number; name: string }[] | undefined>(grouped2.C);

--- a/test/groupBy.test.ts
+++ b/test/groupBy.test.ts
@@ -1,0 +1,16 @@
+import { groupBy } from '../es';
+
+const byGrade = groupBy((student: { score: number; name: string }) => {
+  const score = student.score;
+  return score < 65 ? 'F' : score < 70 ? 'D' : score < 80 ? 'C' : score < 90 ? 'B' : 'A';
+});
+const students = [
+  { name: 'Abby', score: 84 },
+  { name: 'Eddy', score: 58 },
+  { name: 'Jack', score: 69 }
+];
+
+const grouped = byGrade(students);
+(grouped.C ?? []).length;
+// @ts-expect-error
+grouped.C.length;

--- a/types/groupBy.d.ts
+++ b/types/groupBy.d.ts
@@ -1,2 +1,5 @@
-export function groupBy<T, K extends string = string>(fn: (a: T) => K, list: readonly T[]): Partial<Record<K, T[]>>;
+import { Placeholder } from './util/tools';
+
 export function groupBy<T, K extends string = string>(fn: (a: T) => K): (list: readonly T[]) => Partial<Record<K, T[]>>;
+export function groupBy<T>(__: Placeholder, list: readonly T[]): <K extends string = string>(fn: (a: T) => K) => Partial<Record<K, T[]>>;
+export function groupBy<T, K extends string = string>(fn: (a: T) => K, list: readonly T[]): Partial<Record<K, T[]>>;

--- a/types/groupBy.d.ts
+++ b/types/groupBy.d.ts
@@ -1,2 +1,2 @@
-export function groupBy<T, K extends string = string>(fn: (a: T) => K, list: readonly T[]): Record<K, T[]>;
-export function groupBy<T, K extends string = string>(fn: (a: T) => K): (list: readonly T[]) => Record<K, T[]>;
+export function groupBy<T, K extends string = string>(fn: (a: T) => K, list: readonly T[]): Partial<Record<K, T[]>>;
+export function groupBy<T, K extends string = string>(fn: (a: T) => K): (list: readonly T[]) => Partial<Record<K, T[]>>;


### PR DESCRIPTION
The grouping classifier function may have never returned one of the possible values, so there is not necessarily an array for each group.

Note: The test is sort of copied from DefinitelyTyped.
I noticed you seem to use `tsd expect*` functions in the other test, but wanted to avoid putting a huge `expectType` of sorts.
Testing this way seems like a pretty good idea here, because it's user-focused ('this expression with the groupBy result is allowed, this one is not').
Feel free to amend the test if you don't like that part.
