### PR TITLE
Draft: Update: Filter

### DIFF
--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -6,7 +6,7 @@ type Foobar = 'foo' | 'bar' | undefined;
 // filter(isNotNil, list)
 expectType<Array<'foo' | 'bar'>>(filter(isNotNil, [] as Foobar[]));
 // filter(isNotNil)(lint)
-expectType<Foobar[]>(filter(isNotNil)([] as Foobar[]));
+expectType<Array<'foo' | 'bar'>>(filter(isNotNil)([] as Foobar[]));
 // filter(__, list)(isNotNil)
 expectType<Array<'foo' | 'bar'>>(filter(__, [] as Foobar[])(isNotNil));
 
@@ -23,15 +23,14 @@ expectType<number[]>(filter(gt5)(typed));
 expectType<number[]>(filter(gt5, infered));
 expectType<number[]>(filter(gt5)(infered));
 // readonly
-expectType<readonly number[]>(filter(gt5, readOnlyArr));
+expectType<number[]>(filter(gt5, readOnlyArr));
 expectType<number[]>(filter(gt5)(readOnlyArr));
 // literal
 expectType<number[]>(filter(gt5, [1, 4, 6, 10]));
 expectType<number[]>(filter(gt5)([1, 4, 6, 10]));
 // tuple
 expectNotType<number[]>(filter(gt5, tuple));
-// when curried, you get -readonly [1, 4, 6, 10], need to figure out this one
-expectType<[1, 4, 6, 10]>(filter(gt5)(tuple));
+expectType<number[]>(filter(gt5)(tuple));
 
 // pipe
 expectType<number[]>(pipe(filter(gt5))(typed));
@@ -52,12 +51,11 @@ expectType<number[]>(filter(__, readOnlyArr)(gt5));
 //
 // object
 //
-
-type Dictionary = Record<string, 'foo' | 'bar' | undefined>;
+type Dictionary = Record<'a' | 'b', 'foo' | 'bar' | undefined>;
 // filter(isNotNil, dict)
-expectType<Record<keyof Dictionary, 'foo' | 'bar'>>(filter(isNotNil, {} as Dictionary));
+expectType<Partial<Record<keyof Dictionary, 'foo' | 'bar'>>>(filter(isNotNil, {} as Dictionary));
 // // filter(isNotNil)(dict),  doesn't get the benefit of type narrows :-(
-expectType<Dictionary>(filter(isNotNil)({} as Dictionary));
+expectType<Partial<Record<keyof Dictionary, 'foo' | 'bar'>>>(filter<'o', 'foo' | 'bar' | undefined, 'foo' | 'bar'>(isNotNil)({} as Dictionary));
 
 type Obj = { foo: number; bar: number; };
 
@@ -66,7 +64,7 @@ const inferedO = { foo: 4, bar: 6 };
 const asConst = { foo: 4, bar: 6 } as const;
 
 // typed variables
-expectType<Obj>(filter(gt5, typedO));
+expectType<Obj>(filter<'o'>(gt5, typedO));
 expectType<Obj>(filter(gt5)(typedO));
 // un-typed variable
 expectType<Obj>(filter(gt5, inferedO));

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -1,0 +1,96 @@
+import { expectNotType, expectType } from 'tsd';
+import { __, compose, filter, identity, isNotNil, pipe, map } from '../es';
+
+type Foobar = 'foo' | 'bar' | undefined;
+
+// filter(isNotNil, list)
+expectType<Array<'foo' | 'bar'>>(filter(isNotNil, [] as Foobar[]));
+// filter(isNotNil)(lint)
+expectType<Foobar[]>(filter(isNotNil)([] as Foobar[]));
+// filter(__, list)(isNotNil)
+expectType<Array<'foo' | 'bar'>>(filter(__, [] as Foobar[])(isNotNil));
+
+const gt5 = (num: number) => num > 5;
+const typed: number[] = [];
+const infered = [1, 4, 6, 10];
+const readOnlyArr: readonly number[] = [1, 4, 6, 10];
+const tuple = [1, 4, 6, 10] as const;
+
+// typed variables
+expectType<number[]>(filter(gt5, typed));
+expectType<number[]>(filter(gt5)(typed));
+// un-typed variable
+expectType<number[]>(filter(gt5, infered));
+expectType<number[]>(filter(gt5)(infered));
+// readonly
+expectType<readonly number[]>(filter(gt5, readOnlyArr));
+expectType<number[]>(filter(gt5)(readOnlyArr));
+// literal
+expectType<number[]>(filter(gt5, [1, 4, 6, 10]));
+expectType<number[]>(filter(gt5)([1, 4, 6, 10]));
+// tuple
+expectNotType<number[]>(filter(gt5, tuple));
+// when curried, you get -readonly [1, 4, 6, 10], need to figure out this one
+expectType<[1, 4, 6, 10]>(filter(gt5)(tuple));
+
+// pipe
+expectType<number[]>(pipe(filter(gt5))(typed));
+expectType<number[]>(pipe(filter(gt5), map(identity))(typed));
+
+// compose
+expectType<number[]>(compose(filter(gt5))(typed));
+expectType<number[]>(compose(map(identity), filter(gt5))(typed));
+
+// curried
+// typed variables
+expectType<number[]>(filter(__, typed)(gt5));
+// un-typed variable
+expectType<number[]>(filter(__, infered)(gt5));
+// readonly
+expectType<number[]>(filter(__, readOnlyArr)(gt5));
+
+//
+// object
+//
+
+type Dictionary = Record<string, 'foo' | 'bar' | undefined>;
+// filter(isNotNil, dict)
+expectType<Record<keyof Dictionary, 'foo' | 'bar'>>(filter(isNotNil, {} as Dictionary));
+// // filter(isNotNil)(dict),  doesn't get the benefit of type narrows :-(
+expectType<Dictionary>(filter(isNotNil)({} as Dictionary));
+
+type Obj = { foo: number; bar: number; };
+
+const typedO: Obj = { foo: 4, bar: 6 };
+const inferedO = { foo: 4, bar: 6 };
+const asConst = { foo: 4, bar: 6 } as const;
+
+// typed variables
+expectType<Obj>(filter(gt5, typedO));
+expectType<Obj>(filter(gt5)(typedO));
+// un-typed variable
+expectType<Obj>(filter(gt5, inferedO));
+expectType<Obj>(filter(gt5)(inferedO));
+// readonly
+expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(gt5, asConst));
+expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(gt5)(asConst));
+// literal
+expectType<Obj>(filter(gt5, { foo: 4, bar: 6 }));
+expectType<Obj>(filter(gt5)({ foo: 4, bar: 6 }));
+
+// pipe
+expectType<Obj>(pipe(filter(gt5), map(identity))(typedO));
+expectType<Obj>(pipe(map(identity), filter(gt5))(typedO));
+
+// compose
+expectType<Obj>(compose(filter(gt5))(typedO));
+
+// curried
+// typed variables
+expectType<Record<keyof Obj, number>>(filter(__, typedO)(gt5));
+// un-typed variable
+expectType<Obj>(filter(__, inferedO)(gt5));
+// readonly
+expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(__, asConst)(gt5));
+// literal
+expectType<Obj>(filter(__, { foo: 4, bar: 6 })(gt5));

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -6,8 +6,8 @@ type StringOrUndefined = string | undefined;
 
 // when the predicate that is passed to filter has a generic argument, such as `isNotNil`
 // when a predicate with a generic is passed to filter, using the curried variety collapses to unknown
-expectType<unknown[]>(filter(isNotNil)([] as StringOrUndefined[]));
-expectType<Record<string, unknown>>(filter(isNotNil)({} as Record<string, StringOrUndefined>));
+expectAssignable<unknown[]>(filter(isNotNil)([] as StringOrUndefined[]));
+expectAssignable<Record<string, unknown>>(filter(isNotNil)({} as Record<string, StringOrUndefined>));
 
 // when calling filter(pred, list) or filter(pred, dict), this is not an issue
 expectType<string[]>(filter(isNotNil, [] as StringOrUndefined[]));
@@ -15,12 +15,11 @@ expectType<Partial<Record<string, string>>>(filter(isNotNil, {} as Record<string
 
 // because if this, it is recommended not to create functions like this
 const filterNils = filter(isNotNil);
-expectType<(list: unknown[]) => unknown[]>(filterNils);
 // unless you set the type themselves
 const filterNils2: <T>(list: T[]) => NonNullable<T>[] = filter(isNotNil);
 
 // this problem persists when using `filter(pred)` with `pipe`/`compose`
-expectType<(list: readonly unknown[]) => unknown[]>(pipe(filter(isNotNil)));
+expectAssignable<(list: readonly unknown[]) => unknown[]>(pipe(filter(isNotNil)));
 // to get around this, simply wrap with an arrow function
 expectAssignable<<T>(list: readonly T[]) => NonNullable<T>[]>(pipe(<T>(xs: readonly T[]) => filter(isNotNil, xs)));
 
@@ -66,7 +65,7 @@ expectType<number[]>(filter(__, typed)(gt5));
 // un-typed variable
 expectType<number[]>(filter(__, inferred)(gt5));
 // readonly
-expectType<readonly number[]>(filter(__, readOnlyArr)(gt5));
+expectType<number[]>(filter(__, readOnlyArr)(gt5));
 
 //
 // object

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -1,16 +1,16 @@
 import { expectNotType, expectType } from 'tsd';
 import { __, compose, filter, identity, isNotNil, pipe, map } from '../es';
 
-type Foobar = 'foo' | 'bar' | undefined;
+type StringOrUndefined = string | undefined;
 declare function testFunc<T>(arg: T) : boolean;
 
-expectType<Array<'foo' | 'bar'>>(filter(isNotNil, [] as Foobar[]));
-expectType<Array<'foo' | 'bar'>>(filter(isNotNil)([] as Foobar[]));
-expectType<Array<'foo' | 'bar'>>(filter(__, [] as Foobar[])(isNotNil));
+expectType<string[]>(filter(isNotNil, [] as StringOrUndefined[]));
+expectType<string[]>(filter(isNotNil)([] as StringOrUndefined[]));
+expectType<string[]>(filter(__, [] as StringOrUndefined[])(isNotNil));
 
-expectType<Foobar[]>(filter(testFunc, [] as Foobar[]));
-expectType<Foobar[]>(filter(testFunc)([] as Foobar[]));
-expectType<Foobar[]>(filter(__, [] as Foobar[])(testFunc));
+expectType<StringOrUndefined[]>(filter(testFunc, [] as StringOrUndefined[]));
+expectType<StringOrUndefined[]>(filter(testFunc)([] as StringOrUndefined[]));
+expectType<StringOrUndefined[]>(filter(__, [] as StringOrUndefined[])(testFunc));
 
 const gt5 = (num: number) => num > 5;
 const typed: number[] = [];
@@ -44,7 +44,8 @@ expectType<number[]>(pipe(filter(gt5), map(identity))(typed));
 
 // compose
 expectType<number[]>(compose(filter(gt5))(typed));
-expectType<number[]>(compose(map(identity), filter(gt5))(typed));
+// this one works for pipe above, but does not for compose, the issue is likely the compose definition and not filter
+// expectType<number[]>(compose(map(identity), filter(gt5))(typed));
 
 // curried
 // typed variables
@@ -57,11 +58,11 @@ expectType<readonly number[]>(filter(__, readOnlyArr)(gt5));
 //
 // object
 //
-type Dictionary = Record<'a' | 'b', 'foo' | 'bar' | undefined>;
+type Dictionary = Record<'a' | 'b', string | undefined>;
 // filter(isNotNil, dict)
-expectType<Partial<Record<keyof Dictionary, 'foo' | 'bar'>>>(filter(isNotNil, {} as Dictionary));
+expectType<Partial<Record<keyof Dictionary, string>>>(filter(isNotNil, {} as Dictionary));
 // // filter(isNotNil)(dict),  doesn't get the benefit of type narrows :-(
-// expectType<Partial<Record<keyof Dictionary, 'foo' | 'bar'>>>(filter<'o', 'foo' | 'bar' | undefined, 'foo' | 'bar'>(isNotNil)({} as Dictionary));
+// expectType<Partial<Record<keyof Dictionary, string>>>(filter<'o', string | undefined, string>(isNotNil)({} as Dictionary));
 
 type Obj = { foo: number; bar: number; };
 

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -4,20 +4,19 @@ import { __, compose, filter, identity, isNotNil, pipe, map } from '../es';
 
 type StringOrUndefined = string | undefined;
 
-// when the predicate that is passed to filter has a generic argument, such as `isNotNil`
-// typescript collapses `T` to `unknown`
-expectAssignable<unknown[]>(filter(isNotNil)([] as StringOrUndefined[]));
-expectAssignable<unknown[]>(filter(isNotNil, [] as StringOrUndefined[]));
-expectAssignable<Record<string, unknown>>(filter(isNotNil)({} as Record<string, StringOrUndefined>));
-expectAssignable<Record<string, unknown>>(filter(isNotNil, {} as Record<string, StringOrUndefined>));
+// filter(pred)(filterable)
+// purposefully no support for object, see https://github.com/ramda/types/discussions/54
+expectType<string[]>(filter(isNotNil)([] as StringOrUndefined[]));
 
-// this is fixable by setting the generic on isNotNil
-expectType<string[]>(filter(isNotNil<StringOrUndefined>)([] as StringOrUndefined[]));
-expectType<string[]>(filter(isNotNil<StringOrUndefined>, [] as StringOrUndefined[]));
-expectType<Partial<Record<string, string>>>(filter(isNotNil<StringOrUndefined>)({} as Record<string, StringOrUndefined>));
+// filter(pred, filterable)
 expectType<Partial<Record<string, string>>>(filter(isNotNil<StringOrUndefined>, {} as Record<string, StringOrUndefined>));
-expectType<string[]>(filter(__, [] as StringOrUndefined[])(isNotNil<StringOrUndefined>));
-expectType<Partial<Record<string, string>>>(filter(__, {} as Record<string, StringOrUndefined>)(isNotNil<StringOrUndefined>));
+expectType<string[]>(filter(isNotNil, [] as StringOrUndefined[]));
+
+// filter(__, filterable)(pred)
+expectType<Partial<Record<string, string>>>(filter(__, {} as Record<string, StringOrUndefined>)(isNotNil));
+expectType<string[]>(filter(__, [] as StringOrUndefined[])(isNotNil));
+
+
 
 const gt5 = (num: number) => num > 5;
 const typed: number[] = [];
@@ -40,7 +39,7 @@ expectType<number[]>(filter(gt5)(readOnlyArr));
 expectType<number[]>(filter(gt5, [1, 4, 6, 10]));
 expectType<number[]>(filter(gt5)([1, 4, 6, 10]));
 // constArray
-expectType<number[]>(filter(gt5, constArray));
+expectType<(1 | 4 | 6 | 10)[]>(filter(gt5, constArray));
 expectType<number[]>(filter(gt5)(constArray));
 // tuple
 expectType<number[]>(filter(gt5, tuple));
@@ -65,16 +64,12 @@ const asConst = { foo: 4, bar: 6 } as const;
 
 // typed variables
 expectType<Partial<Obj>>(filter(gt5, typedO));
-expectType<Partial<Obj>>(filter(gt5)(typedO));
 // un-typed variable
 expectType<Partial<Obj>>(filter(gt5, inferredO));
-expectType<Partial<Obj>>(filter(gt5)(inferredO));
 // readonly
 expectType<Partial<{ readonly foo: 4, readonly bar: 6 }>>(filter(gt5, asConst));
-expectType<Partial<{ readonly foo: 4, readonly bar: 6 }>>(filter(gt5)(asConst));
 // literal
 expectType<Partial<Obj>>(filter(gt5, { foo: 4, bar: 6 }));
-expectType<Partial<Obj>>(filter(gt5)({ foo: 4, bar: 6 }));
 
 // pipe
 // the last overload is always selected when passing a function as an argument to a function like pipe
@@ -89,6 +84,6 @@ expectType<Partial<Record<keyof Obj, number>>>(filter(__, typedO)(gt5));
 // un-typed variable
 expectType<Partial<Obj>>(filter(__, inferredO)(gt5));
 // readonly
-expectType<Partial<Record<'foo' | 'bar', 4 | 6>>>(filter(__, asConst)(gt5));
+expectType<Partial<{ readonly foo: 4; readonly bar: 6; }>>(filter(__, asConst)(gt5));
 // literal
 expectType<Partial<Obj>>(filter(__, { foo: 4, bar: 6 })(gt5));

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -67,15 +67,15 @@ expectType<Partial<Record<keyof Dictionary, string>>>(filter(isNotNil, {} as Dic
 type Obj = { foo: number; bar: number; };
 
 const typedO: Obj = { foo: 4, bar: 6 };
-const inferedO = { foo: 4, bar: 6 };
+const inferredO = { foo: 4, bar: 6 };
 const asConst = { foo: 4, bar: 6 } as const;
 
 // typed variables
 // expectType<Obj>(filter<'o'>(gt5, typedO));
 // expectType<Obj>(filter(gt5)(typedO));
 // un-typed variable
-// expectType<Obj>(filter(gt5, inferedO));
-// expectType<Obj>(filter(gt5)(inferedO));
+// expectType<Obj>(filter(gt5, inferredO));
+// expectType<Obj>(filter(gt5)(inferredO));
 // readonly
 // expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(gt5, asConst));
 // expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(gt5)(asConst));
@@ -94,7 +94,7 @@ const asConst = { foo: 4, bar: 6 } as const;
 // typed variables
 expectType<Record<keyof Obj, number>>(filter(__, typedO)(gt5));
 // un-typed variable
-expectType<Obj>(filter(__, inferedO)(gt5));
+expectType<Obj>(filter(__, inferredO)(gt5));
 // readonly
 expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(__, asConst)(gt5));
 // literal

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -2,26 +2,32 @@ import { expectNotType, expectType } from 'tsd';
 import { __, compose, filter, identity, isNotNil, pipe, map } from '../es';
 
 type Foobar = 'foo' | 'bar' | undefined;
+declare function testFunc<T>(arg: T) : boolean;
 
-// filter(isNotNil, list)
 expectType<Array<'foo' | 'bar'>>(filter(isNotNil, [] as Foobar[]));
-// filter(isNotNil)(lint)
 expectType<Array<'foo' | 'bar'>>(filter(isNotNil)([] as Foobar[]));
-// filter(__, list)(isNotNil)
 expectType<Array<'foo' | 'bar'>>(filter(__, [] as Foobar[])(isNotNil));
+
+expectType<Foobar[]>(filter(testFunc, [] as Foobar[]));
+expectType<Foobar[]>(filter(testFunc)([] as Foobar[]));
+expectType<Foobar[]>(filter(__, [] as Foobar[])(testFunc));
 
 const gt5 = (num: number) => num > 5;
 const typed: number[] = [];
-const infered = [1, 4, 6, 10];
+const inferred = [1, 4, 6, 10];
 const readOnlyArr: readonly number[] = [1, 4, 6, 10];
 const tuple = [1, 4, 6, 10] as const;
+
+
+expectType<number[]>(filter(testFunc, typed));
+expectType<number[]>(filter(testFunc)(typed));
 
 // typed variables
 expectType<number[]>(filter(gt5, typed));
 expectType<number[]>(filter(gt5)(typed));
 // un-typed variable
-expectType<number[]>(filter(gt5, infered));
-expectType<number[]>(filter(gt5)(infered));
+expectType<number[]>(filter(gt5, inferred));
+expectType<number[]>(filter(gt5)(inferred));
 // readonly
 expectType<number[]>(filter(gt5, readOnlyArr));
 expectType<number[]>(filter(gt5)(readOnlyArr));
@@ -44,9 +50,9 @@ expectType<number[]>(compose(map(identity), filter(gt5))(typed));
 // typed variables
 expectType<number[]>(filter(__, typed)(gt5));
 // un-typed variable
-expectType<number[]>(filter(__, infered)(gt5));
+expectType<number[]>(filter(__, inferred)(gt5));
 // readonly
-expectType<number[]>(filter(__, readOnlyArr)(gt5));
+expectType<readonly number[]>(filter(__, readOnlyArr)(gt5));
 
 //
 // object
@@ -55,7 +61,7 @@ type Dictionary = Record<'a' | 'b', 'foo' | 'bar' | undefined>;
 // filter(isNotNil, dict)
 expectType<Partial<Record<keyof Dictionary, 'foo' | 'bar'>>>(filter(isNotNil, {} as Dictionary));
 // // filter(isNotNil)(dict),  doesn't get the benefit of type narrows :-(
-expectType<Partial<Record<keyof Dictionary, 'foo' | 'bar'>>>(filter<'o', 'foo' | 'bar' | undefined, 'foo' | 'bar'>(isNotNil)({} as Dictionary));
+// expectType<Partial<Record<keyof Dictionary, 'foo' | 'bar'>>>(filter<'o', 'foo' | 'bar' | undefined, 'foo' | 'bar'>(isNotNil)({} as Dictionary));
 
 type Obj = { foo: number; bar: number; };
 
@@ -64,24 +70,24 @@ const inferedO = { foo: 4, bar: 6 };
 const asConst = { foo: 4, bar: 6 } as const;
 
 // typed variables
-expectType<Obj>(filter<'o'>(gt5, typedO));
-expectType<Obj>(filter(gt5)(typedO));
+// expectType<Obj>(filter<'o'>(gt5, typedO));
+// expectType<Obj>(filter(gt5)(typedO));
 // un-typed variable
-expectType<Obj>(filter(gt5, inferedO));
-expectType<Obj>(filter(gt5)(inferedO));
+// expectType<Obj>(filter(gt5, inferedO));
+// expectType<Obj>(filter(gt5)(inferedO));
 // readonly
-expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(gt5, asConst));
-expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(gt5)(asConst));
+// expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(gt5, asConst));
+// expectType<{ readonly foo: 4, readonly bar: 6 }>(filter(gt5)(asConst));
 // literal
-expectType<Obj>(filter(gt5, { foo: 4, bar: 6 }));
-expectType<Obj>(filter(gt5)({ foo: 4, bar: 6 }));
+// expectType<Obj>(filter(gt5, { foo: 4, bar: 6 }));
+// expectType<Obj>(filter(gt5)({ foo: 4, bar: 6 }));
 
 // pipe
-expectType<Obj>(pipe(filter(gt5), map(identity))(typedO));
-expectType<Obj>(pipe(map(identity), filter(gt5))(typedO));
+// expectType<Obj>(pipe(filter(gt5), map(identity))(typedO));
+// expectType<Obj>(pipe(map(identity), filter(gt5))(typedO));
 
 // compose
-expectType<Obj>(compose(filter(gt5))(typedO));
+// expectType<Obj>(compose(filter(gt5))(typedO));
 
 // curried
 // typed variables

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -1,15 +1,6 @@
 import * as _ from 'ts-toolbelt';
 import { Placeholder } from './util/tools';
 
-// `val as P` is for type narrowing
-// must have a `boolean` option as well for if predicate does not narrow
-// see for details:
-// https://www.typescriptlang.org/play?#code/C4TwDgpgBAysBOBLAdgcwPLwHIFcC2ARhPFALxQDOCKqUAPlMvkfANwCwAUFwMYD2yKlEQU4SNGSgAKAG4BDADYAuWNTSZchYgEoV8hcIqU1tUgD4ooSHwBmUfWVLkA5FXGpnHTv0HBDmlklZRRUxGg1mHT1FQ0ZIknNLcAhbexinFyYteE9eASERADFFChAg-VCTCOzdKAI+PgUIOWQyCwBCdv0vLgATCB4FOXhoGxxkHmBEASgbRAVgYgAeABUAGigABSgIAA9F5F6jFbMpMBHelWDlKBXtNrSDES2NhRFgFRG5XoEFMpWANoAXVqm2BXn6g2Go3Gk2mrTmC2WJzOFyuFVu90S9UazWQr3en2aP2Qf1uwNqgKBPW8+T8byolXc1RYwMkAIADBtnM4NgBGblyXlQABM3IIzmpXDyvig8D5kkRi3gUhEYTQBKo2i8AHodVADVAAHoAfhlQngIsV82VqooAWImuA2q4esNxrNtNl8AAzNakSqiiUQE6XZw3YbTVwgA
-export function filter<T, P extends T = T>(pred: (val: T) => val is P, list: T[]): P[];
-export function filter<T, P extends T = T>(pred: (val: T) => val is P, list: readonly T[]): readonly P[];
-export function filter<T extends U[keyof U], P extends T = T, U = any>(pred: (val: T) => val is P, dict: U): Record<keyof U, P>;
-export function filter<T>(pred: (val: T) => boolean, list: T[]): T[];
-export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): readonly T[];
 export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U): U;
 // filter(__, list)(pred)
 export function filter<T>(__: Placeholder, list: readonly T[]): {
@@ -28,3 +19,14 @@ export function filter<T>(pred: (val: T) => boolean): <C extends readonly T[] | 
 //   <U extends readonly T[]>(list: U extends readonly T[] ? U : never): U extends readonly T[] ? _.L.Writable<U> : never;
 //   <U extends Record<PropertyKey, T>>(dict: U extends readonly T[] ? never : U): U extends T[] ? never : U;
 // };
+
+// filter(pred, list)
+// do the object variant first
+export function filter<T extends U[keyof U], P extends T = T, U = any>(pred: (val: T) => val is P, dict: U): Record<keyof U, P>;
+// this overload is to support when the predicate returns``val is p`, otherwise you'd lose that bit on the
+// See for details: https://tsplay.dev/WoYjeN
+export function filter<T, P extends T = T>(pred: (val: T) => val is P, list: T[]): P[];
+export function filter<T, P extends T = T>(pred: (val: T) => val is P, list: readonly T[]): readonly P[];
+// and finally, the regular `(val: T) => boolean` overload
+export function filter<T>(pred: (val: T) => boolean, list: T[]): T[];
+export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): readonly T[];

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -5,7 +5,9 @@ export function filter<T, P extends T>(pred: (val: T) => val is P): (list: reado
 export function filter<T>(pred: (val: T) => boolean): (list: readonly T[]) => T[];
 
 // see `map` for details
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function filter<H extends 'o', T = unknown, P extends T = T>(pred: (val: T) => val is P): <U extends Record<PropertyKey, T>>(dict: U) => Partial<Record<keyof U, P>>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function filter<H extends 'o', T>(pred: (val: T) => boolean): <U extends Record<PropertyKey, T>>(dict: U) => Partial<U>;
 
 // filter(__, list)(pred)
@@ -15,7 +17,7 @@ export function filter<T>(__: Placeholder, list: readonly T[]): {
 };
 // filter(__, dict)(pred)
 export function filter<U extends object>(__: Placeholder, dict: U): {
-  <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Record<keyof U, P>
+  <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Record<keyof U, P>;
   <T extends U[keyof U]>(pred: (val: T) => boolean): U;
 };
 

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -1,12 +1,30 @@
-export function filter<A, P extends A>(
-  pred: (val: A) => val is P,
-): {
-  <B extends A>(list: readonly B[]): P[];
-  <B extends A>(dict: Record<string, B>): Record<string, P>;
+import * as _ from 'ts-toolbelt';
+import { Placeholder } from './util/tools';
+
+// `val as P` is for type narrowing
+// must have a `boolean` option as well for if predicate does not narrow
+// see for details:
+// https://www.typescriptlang.org/play?#code/C4TwDgpgBAysBOBLAdgcwPLwHIFcC2ARhPFALxQDOCKqUAPlMvkfANwCwAUFwMYD2yKlEQU4SNGSgAKAG4BDADYAuWNTSZchYgEoV8hcIqU1tUgD4ooSHwBmUfWVLkA5FXGpnHTv0HBDmlklZRRUxGg1mHT1FQ0ZIknNLcAhbexinFyYteE9eASERADFFChAg-VCTCOzdKAI+PgUIOWQyCwBCdv0vLgATCB4FOXhoGxxkHmBEASgbRAVgYgAeABUAGigABSgIAA9F5F6jFbMpMBHelWDlKBXtNrSDES2NhRFgFRG5XoEFMpWANoAXVqm2BXn6g2Go3Gk2mrTmC2WJzOFyuFVu90S9UazWQr3en2aP2Qf1uwNqgKBPW8+T8byolXc1RYwMkAIADBtnM4NgBGblyXlQABM3IIzmpXDyvig8D5kkRi3gUhEYTQBKo2i8AHodVADVAAHoAfhlQngIsV82VqooAWImuA2q4esNxrNtNl8AAzNakSqiiUQE6XZw3YbTVwgA
+export function filter<T, P extends T = T>(pred: (val: T) => val is P, list: T[]): P[];
+export function filter<T, P extends T = T>(pred: (val: T) => val is P, list: readonly T[]): readonly P[];
+export function filter<T extends U[keyof U], P extends T = T, U = any>(pred: (val: T) => val is P, dict: U): Record<keyof U, P>;
+export function filter<T>(pred: (val: T) => boolean, list: T[]): T[];
+export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): readonly T[];
+export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U): U;
+// filter(__, list)(pred)
+export function filter<T>(__: Placeholder, list: readonly T[]): {
+  <P extends T>(pred: (val: T) => val is P): P[];
+  (pred: (val: T) => boolean): T[];
 };
-export function filter<T>(
-  pred: (value: T) => boolean,
-): <P extends T, C extends readonly P[] | Record<string, P>>(collection: C) => C;
-export function filter<T, P extends T>(pred: (val: T) => val is P, list: readonly T[]): P[];
-export function filter<T, P extends T>(pred: (val: T) => val is P, dict: Record<string, T>): Record<string, P>;
-export function filter<T, C extends readonly T[] | Record<string, T>>(pred: (value: T) => boolean, collection: C): C;
+// filter(__, dict)(pred)
+export function filter<U extends object>(__: Placeholder, dict: U): {
+  <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Record<keyof U, P>
+  <T extends U[keyof U]>(pred: (val: T) => boolean): U;
+};
+// filter(pred)(listOrDict)
+// have yet to get `val is P` variety working here, if anyone knows please help!
+export function filter<T>(pred: (val: T) => boolean): <C extends readonly T[] | Record<PropertyKey, T>>(collection: C) => C extends readonly T[] ? _.L.Writable<C> : C;
+// export function filter<T>(pred: (val: T) => boolean): {
+//   <U extends readonly T[]>(list: U extends readonly T[] ? U : never): U extends readonly T[] ? _.L.Writable<U> : never;
+//   <U extends Record<PropertyKey, T>>(dict: U extends readonly T[] ? never : U): U extends T[] ? never : U;
+// };

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -1,7 +1,13 @@
-import * as _ from 'ts-toolbelt';
 import { Placeholder } from './util/tools';
 
-export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U): U;
+// filter(pred)
+export function filter<T, P extends T>(pred: (val: T) => val is P): (list: readonly T[]) => P[];
+export function filter<T>(pred: (val: T) => boolean): (list: readonly T[]) => T[];
+
+// see `map` for details
+export function filter<H extends 'o', T = unknown, P extends T = T>(pred: (val: T) => val is P): <U extends Record<PropertyKey, T>>(dict: U) => Partial<Record<keyof U, P>>;
+export function filter<H extends 'o', T>(pred: (val: T) => boolean): <U extends Record<PropertyKey, T>>(dict: U) => Partial<U>;
+
 // filter(__, list)(pred)
 export function filter<T>(__: Placeholder, list: readonly T[]): {
   <P extends T>(pred: (val: T) => val is P): P[];
@@ -12,21 +18,16 @@ export function filter<U extends object>(__: Placeholder, dict: U): {
   <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Record<keyof U, P>
   <T extends U[keyof U]>(pred: (val: T) => boolean): U;
 };
-// filter(pred)(listOrDict)
-// have yet to get `val is P` variety working here, if anyone knows please help!
-export function filter<T>(pred: (val: T) => boolean): <C extends readonly T[] | Record<PropertyKey, T>>(collection: C) => C extends readonly T[] ? _.L.Writable<C> : C;
-// export function filter<T>(pred: (val: T) => boolean): {
-//   <U extends readonly T[]>(list: U extends readonly T[] ? U : never): U extends readonly T[] ? _.L.Writable<U> : never;
-//   <U extends Record<PropertyKey, T>>(dict: U extends readonly T[] ? never : U): U extends T[] ? never : U;
-// };
 
 // filter(pred, list)
-// do the object variant first
-export function filter<T extends U[keyof U], P extends T = T, U = any>(pred: (val: T) => val is P, dict: U): Record<keyof U, P>;
 // this overload is to support when the predicate returns``val is p`, otherwise you'd lose that bit on the
 // See for details: https://tsplay.dev/WoYjeN
-export function filter<T, P extends T = T>(pred: (val: T) => val is P, list: T[]): P[];
-export function filter<T, P extends T = T>(pred: (val: T) => val is P, list: readonly T[]): readonly P[];
-// and finally, the regular `(val: T) => boolean` overload
-export function filter<T>(pred: (val: T) => boolean, list: T[]): T[];
-export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): readonly T[];
+export function filter<T, P extends T>(pred: (val: T) => val is P, list: readonly T[]): P[];
+// and separately defined `pred: (val: T) => boolean`
+export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];
+// do the object variant first
+// always return `Partial` because this filters out keys if they don't match the predicate, and typescript cannot determine itself which keys would be removed
+export function filter<T extends U[keyof U], P extends T, U>(pred: (val: T) => val is P, dict: U): Partial<Record<keyof U, P>>;
+export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U): Partial<U>;
+// re-declare at the end here for when we pass to `flip`, or the like
+export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -1,32 +1,25 @@
 import { Placeholder } from './util/tools';
 
-// filter(pred)
-export function filter<T, P extends T>(pred: (val: T) => val is P): {
-  <U extends Record<PropertyKey, T>>(dict: U extends readonly any[] ? never : U): Partial<Record<keyof U, P>>;
-  (list: readonly T[]): P[];
-};
-export function filter<T>(pred: (val: T) => boolean): {
-  <U extends Record<PropertyKey, T>>(dict: U extends readonly any[] ? never : U): Partial<U>;
-  (list: readonly T[]): T[];
+// filter(pred)(collection)
+export function filter<T, P extends T>(
+  pred: (value: T) => value is P,
+): <C extends readonly T[] | Record<string, T>>(collection: C) => C extends readonly any[] ? P[] : Partial<Record<keyof C, P>>;
+export function filter<T>(
+  pred: (value: T) => boolean,
+): <C extends readonly T[] | Record<string, T>>(collection: C) => C extends readonly any[] ? T[] : Partial<C>;
+
+// filter(__, collection)(pred)
+export function filter<C>(__: Placeholder, dict: C): {
+  <T extends C[keyof C], P extends T>(pred: (val: T) => val is P): C extends readonly any[] ? P[] : Partial<Record<keyof C, P>>;
+  <T extends C[keyof C]>(pred: (val: T) => boolean): C extends readonly any[] ? T[] : Partial<Record<keyof C, T>>;
 };
 
-// filter(__, dict)(pred)
-export function filter<U extends object>(__: Placeholder, dict: U extends readonly any[] ? never : U): {
-  <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Partial<Record<keyof U, P>>;
-  <T extends U[keyof U]>(pred: (val: T) => boolean): Partial<U>;
-};
-
-// filter(__, list)(pred)
-export function filter<T>(__: Placeholder, list: readonly T[]): {
-  <P extends T>(pred: (val: T) => val is P): P[];
-  (pred: (val: T) => boolean): T[];
-};
-
-// filter(pred, list)
-// do the object variant first
-// always return `Partial` because this filters out keys if they don't match the predicate, and typescript cannot determine itself which keys would be removed
-export function filter<T extends U[keyof U], P extends T, U>(pred: (val: T) => val is P, dict: U extends readonly any[] ? never : U): Partial<Record<keyof U, P>>;
-export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U extends readonly any[] ? never : U): Partial<U>;
-// array variant second
-export function filter<T, P extends T>(pred: (val: T) => val is P, list: readonly T[]): P[];
-export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];
+// filter(pred, collection)
+export function filter<T, P extends T, C extends readonly T[] | Record<PropertyKey, T>>(
+  pred: (value: T) => value is P,
+  collection: C
+): C extends readonly T[] ? P[] : Partial<Record<keyof C, P>>;
+export function filter<T, C extends readonly T[] | Record<PropertyKey, T>>(
+  pred: (value: T) => boolean,
+  collection: C
+): C extends readonly any[] ? T[] : Partial<C>;

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -2,21 +2,18 @@ import { Placeholder } from './util/tools';
 
 // filter(pred)
 export function filter<T, P extends T>(pred: (val: T) => val is P): {
-  // when pred is `<T>(val: T) => val is P`, `T` collapses to unknown when this is overloaded
-  // but doesn't when its not, why is that?
-  // <U extends Record<PropertyKey, T>>(dict: U extends any[] ? never : U): Partial<Record<keyof U, P>>;
+  <U extends Record<PropertyKey, T>>(dict: U extends readonly any[] ? never : U): Partial<Record<keyof U, P>>;
   (list: readonly T[]): P[];
 };
 export function filter<T>(pred: (val: T) => boolean): {
-  // same here
-  // <U extends Record<PropertyKey, T>>(dict: U extends any[] ? never : U): Partial<U>;
+  <U extends Record<PropertyKey, T>>(dict: U extends readonly any[] ? never : U): Partial<U>;
   (list: readonly T[]): T[];
 };
 
 // filter(__, dict)(pred)
-export function filter<U extends object>(__: Placeholder, dict: U extends any[] ? never : U): {
-  <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Record<keyof U, P>;
-  <T extends U[keyof U]>(pred: (val: T) => boolean): U;
+export function filter<U extends object>(__: Placeholder, dict: U extends readonly any[] ? never : U): {
+  <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Partial<Record<keyof U, P>>;
+  <T extends U[keyof U]>(pred: (val: T) => boolean): Partial<U>;
 };
 
 // filter(__, list)(pred)
@@ -28,8 +25,8 @@ export function filter<T>(__: Placeholder, list: readonly T[]): {
 // filter(pred, list)
 // do the object variant first
 // always return `Partial` because this filters out keys if they don't match the predicate, and typescript cannot determine itself which keys would be removed
-export function filter<T extends U[keyof U], P extends T, U>(pred: (val: T) => val is P, dict: U extends any[] ? never : U): Partial<Record<keyof U, P>>;
-export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U extends any[] ? never : U): Partial<U>;
+export function filter<T extends U[keyof U], P extends T, U>(pred: (val: T) => val is P, dict: U extends readonly any[] ? never : U): Partial<Record<keyof U, P>>;
+export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U extends readonly any[] ? never : U): Partial<U>;
 // array variant second
 export function filter<T, P extends T>(pred: (val: T) => val is P, list: readonly T[]): P[];
 export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -1,23 +1,26 @@
 import { Placeholder } from './util/tools';
 
 // filter(pred)
-declare function filter<T, P extends T>(pred: (val: T) => val is P): {
+export function filter<T, P extends T>(pred: (val: T) => val is P): {
+  // when pred is `<T>(val: T) => val is P`, `T` collapses to unknown when this is overloaded
+  // but doesn't when its not, why is that?
   // <U extends Record<PropertyKey, T>>(dict: U extends any[] ? never : U): Partial<Record<keyof U, P>>;
   (list: readonly T[]): P[];
 };
-declare function filter<T>(pred: (val: T) => boolean): {
+export function filter<T>(pred: (val: T) => boolean): {
+  // same here
   // <U extends Record<PropertyKey, T>>(dict: U extends any[] ? never : U): Partial<U>;
   (list: readonly T[]): T[];
 };
 
 // filter(__, dict)(pred)
-declare function filter<U extends object>(__: Placeholder, dict: U extends any[] ? never : U): {
+export function filter<U extends object>(__: Placeholder, dict: U extends any[] ? never : U): {
   <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Record<keyof U, P>;
   <T extends U[keyof U]>(pred: (val: T) => boolean): U;
 };
 
 // filter(__, list)(pred)
-declare function filter<T>(__: Placeholder, list: readonly T[]): {
+export function filter<T>(__: Placeholder, list: readonly T[]): {
   <P extends T>(pred: (val: T) => val is P): P[];
   (pred: (val: T) => boolean): T[];
 };
@@ -25,8 +28,8 @@ declare function filter<T>(__: Placeholder, list: readonly T[]): {
 // filter(pred, list)
 // do the object variant first
 // always return `Partial` because this filters out keys if they don't match the predicate, and typescript cannot determine itself which keys would be removed
-declare function filter<T extends U[keyof U], P extends T, U>(pred: (val: T) => val is P, dict: U extends any[] ? never : U): Partial<Record<keyof U, P>>;
-declare function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U extends any[] ? never : U): Partial<U>;
+export function filter<T extends U[keyof U], P extends T, U>(pred: (val: T) => val is P, dict: U extends any[] ? never : U): Partial<Record<keyof U, P>>;
+export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U extends any[] ? never : U): Partial<U>;
 // array variant second
-declare function filter<T, P extends T>(pred: (val: T) => val is P, list: readonly T[]): P[];
-declare function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];
+export function filter<T, P extends T>(pred: (val: T) => val is P, list: readonly T[]): P[];
+export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -3,21 +3,21 @@ import { Placeholder, ValueOfUnion } from './util/tools';
 // filter(pred)(list)
 // there is purposefully no support for anything other than T[] here
 // See here: https://github.com/ramda/types/discussions/54
-export function filter<T, P extends T>(pred: (value: T) => value is P): (list: T[]) => P[];
-export function filter<T>(pred: (value: T) => boolean): (list: T[]) => T[];
+export function filter<T, P extends T>(pred: (value: T) => value is P): (filterable: readonly T[]) => P[];
+export function filter<T>(pred: (value: T) => boolean): (filterable: readonly T[]) => T[];
 
 // filter(__, collection)(pred)
-export function filter<U>(__: Placeholder, dict: U): {
-  <T extends ValueOfUnion<U>, P extends T>(pred: (value: T) => value is P): Record<keyof U, P>;
-  <T extends ValueOfUnion<U>>(pred: (value: T) => boolean): U;
+export function filter<U>(__: Placeholder, filterable: U extends readonly any[] ? never : U): {
+  <T extends ValueOfUnion<U>, P extends T>(pred: (value: T) => value is P): Partial<Record<keyof U, P>>;
+  <T extends ValueOfUnion<U>>(pred: (value: T) => boolean): Partial<U>;
 };
-export function filter<T>(__: Placeholder, dict: T[]): {
+export function filter<T>(__: Placeholder, filterable: readonly T[]): {
   <P extends T>(pred: (value: T) => value is P): P[];
   (pred: (value: T) => boolean): T[];
 };
 
 // filter(pred, collection)
-export function filter<U, T extends ValueOfUnion<U>, P extends T>(pred: (value: T) => value is P, obj: U): Record<keyof U, P>;
-export function filter<T, P extends T>(pred: (value: T) => value is P, list: T[]): P[];
-export function filter<U, T extends ValueOfUnion<U>>(pred: (value: T) => boolean, obj: U): U;
-export function filter<T>(pred: (value: T) => boolean, list: T[]): T[];
+export function filter<U, T extends ValueOfUnion<U>, P extends T>(pred: (value: T) => value is P, filterable: U extends readonly any[] ? never : U): Partial<Record<keyof U, P>>;
+export function filter<T, P extends T>(pred: (value: T) => value is P, filterable: readonly T[]): P[];
+export function filter<U, T extends ValueOfUnion<U>>(pred: (value: T) => boolean, filterable: U extends readonly any[] ? never : U): Partial<U>;
+export function filter<T>(pred: (value: T) => boolean, filterable: readonly T[]): T[];

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -1,25 +1,23 @@
-import { Placeholder } from './util/tools';
+import { Placeholder, ValueOfUnion } from './util/tools';
 
-// filter(pred)(collection)
-export function filter<T, P extends T>(
-  pred: (value: T) => value is P,
-): <C extends readonly T[] | Record<string, T>>(collection: C) => C extends readonly any[] ? P[] : Partial<Record<keyof C, P>>;
-export function filter<T>(
-  pred: (value: T) => boolean,
-): <C extends readonly T[] | Record<string, T>>(collection: C) => C extends readonly any[] ? T[] : Partial<C>;
+// filter(pred)(list)
+// there is purposefully no support for anything other than T[] here
+// See here: https://github.com/ramda/types/discussions/54
+export function filter<T, P extends T>(pred: (value: T) => value is P): (list: T[]) => P[];
+export function filter<T>(pred: (value: T) => boolean): (list: T[]) => T[];
 
 // filter(__, collection)(pred)
-export function filter<C>(__: Placeholder, dict: C): {
-  <T extends C[keyof C], P extends T>(pred: (val: T) => val is P): C extends readonly any[] ? P[] : Partial<Record<keyof C, P>>;
-  <T extends C[keyof C]>(pred: (val: T) => boolean): C extends readonly any[] ? T[] : Partial<Record<keyof C, T>>;
+export function filter<U>(__: Placeholder, dict: U): {
+  <T extends ValueOfUnion<U>, P extends T>(pred: (value: T) => value is P): Record<keyof U, P>;
+  <T extends ValueOfUnion<U>>(pred: (value: T) => boolean): U;
+};
+export function filter<T>(__: Placeholder, dict: T[]): {
+  <P extends T>(pred: (value: T) => value is P): P[];
+  (pred: (value: T) => boolean): T[];
 };
 
 // filter(pred, collection)
-export function filter<T, P extends T, C extends readonly T[] | Record<PropertyKey, T>>(
-  pred: (value: T) => value is P,
-  collection: C
-): C extends readonly T[] ? P[] : Partial<Record<keyof C, P>>;
-export function filter<T, C extends readonly T[] | Record<PropertyKey, T>>(
-  pred: (value: T) => boolean,
-  collection: C
-): C extends readonly any[] ? T[] : Partial<C>;
+export function filter<U, T extends ValueOfUnion<U>, P extends T>(pred: (value: T) => value is P, obj: U): Record<keyof U, P>;
+export function filter<T, P extends T>(pred: (value: T) => value is P, list: T[]): P[];
+export function filter<U, T extends ValueOfUnion<U>>(pred: (value: T) => boolean, obj: U): U;
+export function filter<T>(pred: (value: T) => boolean, list: T[]): T[];

--- a/types/filter.d.ts
+++ b/types/filter.d.ts
@@ -1,35 +1,32 @@
 import { Placeholder } from './util/tools';
 
 // filter(pred)
-export function filter<T, P extends T>(pred: (val: T) => val is P): (list: readonly T[]) => P[];
-export function filter<T>(pred: (val: T) => boolean): (list: readonly T[]) => T[];
-
-// see `map` for details
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function filter<H extends 'o', T = unknown, P extends T = T>(pred: (val: T) => val is P): <U extends Record<PropertyKey, T>>(dict: U) => Partial<Record<keyof U, P>>;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function filter<H extends 'o', T>(pred: (val: T) => boolean): <U extends Record<PropertyKey, T>>(dict: U) => Partial<U>;
-
-// filter(__, list)(pred)
-export function filter<T>(__: Placeholder, list: readonly T[]): {
-  <P extends T>(pred: (val: T) => val is P): P[];
-  (pred: (val: T) => boolean): T[];
+declare function filter<T, P extends T>(pred: (val: T) => val is P): {
+  // <U extends Record<PropertyKey, T>>(dict: U extends any[] ? never : U): Partial<Record<keyof U, P>>;
+  (list: readonly T[]): P[];
 };
+declare function filter<T>(pred: (val: T) => boolean): {
+  // <U extends Record<PropertyKey, T>>(dict: U extends any[] ? never : U): Partial<U>;
+  (list: readonly T[]): T[];
+};
+
 // filter(__, dict)(pred)
-export function filter<U extends object>(__: Placeholder, dict: U): {
+declare function filter<U extends object>(__: Placeholder, dict: U extends any[] ? never : U): {
   <T extends U[keyof U], P extends T>(pred: (val: T) => val is P): Record<keyof U, P>;
   <T extends U[keyof U]>(pred: (val: T) => boolean): U;
 };
 
+// filter(__, list)(pred)
+declare function filter<T>(__: Placeholder, list: readonly T[]): {
+  <P extends T>(pred: (val: T) => val is P): P[];
+  (pred: (val: T) => boolean): T[];
+};
+
 // filter(pred, list)
-// this overload is to support when the predicate returns``val is p`, otherwise you'd lose that bit on the
-// See for details: https://tsplay.dev/WoYjeN
-export function filter<T, P extends T>(pred: (val: T) => val is P, list: readonly T[]): P[];
-// and separately defined `pred: (val: T) => boolean`
-export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];
 // do the object variant first
 // always return `Partial` because this filters out keys if they don't match the predicate, and typescript cannot determine itself which keys would be removed
-export function filter<T extends U[keyof U], P extends T, U>(pred: (val: T) => val is P, dict: U): Partial<Record<keyof U, P>>;
-export function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U): Partial<U>;
-// re-declare at the end here for when we pass to `flip`, or the like
-export function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];
+declare function filter<T extends U[keyof U], P extends T, U>(pred: (val: T) => val is P, dict: U extends any[] ? never : U): Partial<Record<keyof U, P>>;
+declare function filter<T, U extends Record<PropertyKey, T>>(pred: (val: T) => boolean, dict: U extends any[] ? never : U): Partial<U>;
+// array variant second
+declare function filter<T, P extends T>(pred: (val: T) => val is P, list: readonly T[]): P[];
+declare function filter<T>(pred: (val: T) => boolean, list: readonly T[]): T[];

--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -1,28 +1,23 @@
 import { FunctorMap, FunctorFantasyLand, Placeholder, ValueOfUnion } from './util/tools';
 
 // map(fn)
-export function map<A, B>(fn: (x: A) => B): {
-  // first and last def are the same and are here on purpose
-  // the list variant needs to come before the FunctorMap ones, because `T[]` is a `FunctorMap<T>`
-  (list: readonly A[]): B[];
-  (functor: FunctorFantasyLand<A>): FunctorFantasyLand<B>;
-  (functor: FunctorMap<A>): FunctorMap<B>;
-  <U extends Record<PropertyKey, A>>(dict: U): Record<keyof U, B>;
-  // it also needs to be here when you pass map as an argument to a function, eg `compose(map(fn))`
-  (list: readonly A[]): B[];
-};
+// there is purposefully no support for anything other than T[] here
+// See here: https://github.com/ramda/types/discussions/54
+export function map<A, B>(fn: (value: A) => B): (list: readonly A[]) => B[];
 
 // map(__, list)
-export function map<A>(__: Placeholder, list: readonly A[]): <B>(fn: (x: A) => B) => B[];
-export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (a: A) => B) => FunctorFantasyLand<B>;
-export function map<A>(__: Placeholder, obj: FunctorMap<A>): <B>(fn: (a: A) => B) => FunctorMap<B>;
-export function map<U extends object>(__: Placeholder, dict: U): <B>(fn: (x: ValueOfUnion<B>) => B) => Record<keyof U, B>;
+// the list variant needs to come before the FunctorMap ones, because `T[]` is a `FunctorMap<T>`
+export function map<A>(__: Placeholder, list: readonly A[]): <B>(fn: (value: A) => B) => B[];
+export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (value: A) => B) => FunctorFantasyLand<B>;
+export function map<A>(__: Placeholder, obj: FunctorMap<A>): <B>(fn: (value: A) => B) => FunctorMap<B>;
+export function map<U extends object>(__: Placeholder, dict: U): <B>(fn: (value: ValueOfUnion<B>) => B) => Record<keyof U, B>;
+
 // map(fn, list)
 // first and last def are the same and are here on purpose
 // the list variant needs to come before the FunctorMap ones, because `T[]` is a `FunctorMap<T>`
-export function map<A, B>(fn: (x: A) => B, list: readonly A[]): B[];
-export function map<A, B>(fn: (x: A) => B, obj: FunctorFantasyLand<A>): FunctorFantasyLand<B>;
-export function map<A, B>(fn: (x: A) => B, obj: FunctorMap<A>): FunctorMap<B>;
+export function map<A, B>(fn: (value: A) => B, list: readonly A[]): B[];
+export function map<A, B>(fn: (value: A) => B, obj: FunctorFantasyLand<A>): FunctorFantasyLand<B>;
+export function map<A, B>(fn: (value: A) => B, obj: FunctorMap<A>): FunctorMap<B>;
 export function map<U extends object, B>(fn: (x: ValueOfUnion<U>) => B, dict: U): Record<keyof U, B>;
 // it also needs to be here when you pass map as an argument to a function, eg `flip(map)`
-export function map<A, B>(fn: (x: A) => B, list: readonly A[]): B[];
+export function map<A, B>(fn: (value: A) => B, list: readonly A[]): B[];


### PR DESCRIPTION
Update to Filter that fixes a few specific issues.

The overload order was previously defined such that when doing `pipe(filter(isEven))` the only expected input type was an object and not an array. The update fixes that and allows for both

Second, the Object variety always returns a `Partial` now, since none of the keys are guaranteed to still be on the object after the `filter`

Third, adds typing for `filter(__, listObj)(pred)` overload

There is a bug with the typescript when passing a function with a generic first arg such as `isNotNil` to `filter()`. The generic collapses to `unknown`. You can work around this by simply setting the generic `filter(isNotNil<number | undefined>)`.

See this playground example: https://tsplay.dev/NdaA0m