### PR TITLE
Update: Concat

### DIFF
--- a/test/concat.test.ts
+++ b/test/concat.test.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd';
+import { expectError, expectType } from 'tsd';
 
 import { __, concat } from '../es';
 
@@ -30,3 +30,7 @@ expectType<number[]>(concat([1, 2, 3], [4, 5, 6] as const));
 expectType<number[]>(concat([1, 2, 3])([4, 5, 6]));
 expectType<number[]>(concat(__, [4, 5, 6])([1, 2, 3]));
 expectType<number[]>(concat([1, 2, 3], [4, 5, 6]));
+
+expectError(concat([] as number[])([] as { foo: string }[]));
+expectError(concat(__, [] as { foo: string }[])([] as number[]));
+expectError(concat([] as number[], [] as { foo: string }[]));

--- a/test/concat.test.ts
+++ b/test/concat.test.ts
@@ -14,23 +14,27 @@ expectType<string>(concat('ABC' as string)('DEF' as string));
 expectType<string>(concat(__, 'DEF' as string)('ABC' as string));
 expectType<string>(concat('ABC' as string, 'DEF' as string));
 
-expectType<number[]>(concat([1, 2, 3] as const)([4, 5, 6] as const));
-expectType<number[]>(concat(__, [4, 5, 6] as const)([1, 2, 3] as const));
-expectType<number[]>(concat([1, 2, 3] as const, [4, 5, 6] as const));
-
-
-expectType<number[]>(concat([1, 2, 3] as const)([4, 5, 6]));
-expectType<number[]>(concat(__, [4, 5, 6])([1, 2, 3] as const));
-expectType<number[]>(concat([1, 2, 3] as const, [4, 5, 6]));
-
-expectType<number[]>(concat([1, 2, 3])([4, 5, 6] as const));
-expectType<number[]>(concat(__, [4, 5, 6] as const)([1, 2, 3]));
-expectType<number[]>(concat([1, 2, 3], [4, 5, 6] as const));
-
+expectType<number[]>([1, 2, 3].concat([4, 5, 6]));
 expectType<number[]>(concat([1, 2, 3])([4, 5, 6]));
 expectType<number[]>(concat(__, [4, 5, 6])([1, 2, 3]));
 expectType<number[]>(concat([1, 2, 3], [4, 5, 6]));
 
+expectError(([1, 2, 3] as [1, 2, 3]).concat([4, 5, 6]));
+expectError(concat([1, 2, 3] as [1, 2, 3])([4, 5, 6]));
+expectError(concat(__, [4, 5, 6])([1, 2, 3] as [1, 2, 3]));
+expectError(concat([1, 2, 3] as [1, 2, 3], [4, 5, 6]));
+
+expectError(([1, 2, 3] as const).concat([4, 5, 6]));
+expectError(concat([1, 2, 3] as const)([4, 5, 6]));
+expectError(concat(__, [4, 5, 6])([1, 2, 3] as const));
+expectError(concat([1, 2, 3] as const, [4, 5, 6]));
+
+expectType<number[]>([1, 2, 3].concat([4, 5, 6] as const));
+expectType<number[]>(concat([1, 2, 3])([4, 5, 6]  as const));
+expectType<number[]>(concat(__, [4, 5, 6]  as const)([1, 2, 3]));
+expectType<number[]>(concat([1, 2, 3], [4, 5, 6] as const));
+
+// sanity check for arrays of completely different types
 expectError(concat([] as number[])([] as { foo: string }[]));
 expectError(concat(__, [] as { foo: string }[])([] as number[]));
 expectError(concat([] as number[], [] as { foo: string }[]));

--- a/test/concat.test.ts
+++ b/test/concat.test.ts
@@ -1,0 +1,19 @@
+import { expectType } from 'tsd';
+
+import { __, concat } from '../es';
+
+expectType<'ABCDEF'>(concat('ABC')('DEF'));
+expectType<'ABCDEF'>(concat(__, 'DEF')('ABC'));
+expectType<'ABCDEF'>(concat('ABC', 'DEF'));
+
+expectType<string>(concat('ABC')('DEF' as string));
+expectType<string>(concat(__, 'DEF' as string)('ABC'));
+expectType<string>(concat('ABC', 'DEF' as string));
+
+expectType<string>(concat('ABC' as string)('DEF' as string));
+expectType<string>(concat(__, 'DEF' as string)('ABC' as string));
+expectType<string>(concat('ABC' as string, 'DEF' as string));
+
+expectType<number[]>(concat([1, 2, 3] as const, [4, 5, 6] as const));
+expectType<number[]>(concat([1, 2, 3] as number[], [4, 5, 6] as number[]));
+expectType<number[]>(concat([1, 2, 3], [4, 5, 6]));

--- a/test/concat.test.ts
+++ b/test/concat.test.ts
@@ -14,6 +14,19 @@ expectType<string>(concat('ABC' as string)('DEF' as string));
 expectType<string>(concat(__, 'DEF' as string)('ABC' as string));
 expectType<string>(concat('ABC' as string, 'DEF' as string));
 
+expectType<number[]>(concat([1, 2, 3] as const)([4, 5, 6] as const));
+expectType<number[]>(concat(__, [4, 5, 6] as const)([1, 2, 3] as const));
 expectType<number[]>(concat([1, 2, 3] as const, [4, 5, 6] as const));
-expectType<number[]>(concat([1, 2, 3] as number[], [4, 5, 6] as number[]));
+
+
+expectType<number[]>(concat([1, 2, 3] as const)([4, 5, 6]));
+expectType<number[]>(concat(__, [4, 5, 6])([1, 2, 3] as const));
+expectType<number[]>(concat([1, 2, 3] as const, [4, 5, 6]));
+
+expectType<number[]>(concat([1, 2, 3])([4, 5, 6] as const));
+expectType<number[]>(concat(__, [4, 5, 6] as const)([1, 2, 3]));
+expectType<number[]>(concat([1, 2, 3], [4, 5, 6] as const));
+
+expectType<number[]>(concat([1, 2, 3])([4, 5, 6]));
+expectType<number[]>(concat(__, [4, 5, 6])([1, 2, 3]));
 expectType<number[]>(concat([1, 2, 3], [4, 5, 6]));

--- a/types/concat.d.ts
+++ b/types/concat.d.ts
@@ -4,13 +4,14 @@ import { Placeholder } from './util/tools';
 export function concat<S1 extends string>(s1: S1): <S2 extends string>(s2: S2) => `${S1}${S2}`;
 export function concat(s1: string): (s2: string) => string;
 // concat(list)(list)
-export function concat<L1 extends any[]>(list1: L1): <L2 extends any[]>(list2: L2) => [...L1, ...L2];
+export function concat<T>(list1: T[]): (list2: T[]) => T[];
 // concat(__, string)(string)
 export function concat<S2 extends string>(__: Placeholder, s2: S2): <S1 extends string>(s1: S1) => `${S1}${S2}`;
+export function concat(__: Placeholder, s2: string): (s1: string) => string;
 // concat(__, list)(list)
-export function concat<L2 extends any[]>(__: Placeholder,list2: L2): <L1 extends any[]>(list1: L1) => [...L1, ...L2];
+export function concat<T>(__: Placeholder, list2: T[]): (list1: T[]) => T[];
 // concat(string, string)
 export function concat<S1 extends string, S2 extends string>(s1: S1, s2: S2): `${S1}${S2}`;
 export function concat(s1: string, s2: string): string;
 // concat(list, list)
-export function concat<L1 extends any[], L2 extends any[]>(list1: L1, list2: L2): [...L1, ...L2];
+export function concat<T>(list1: T[], list2: T[]): T[];

--- a/types/concat.d.ts
+++ b/types/concat.d.ts
@@ -1,20 +1,16 @@
 import { Placeholder } from './util/tools';
 
-export function concat(
-  placeholder: Placeholder,
-): (<L1 extends any[], L2 extends any[]>(list1: L1, list2: L2) => [...L1, ...L2]) &
-(<S1 extends string, S2 extends string>(s1: S1, s2: S2) => `${S1}${S2}`);
-export function concat<L2 extends any[]>(
-  placeholder: Placeholder,
-  list2: L2,
-): <L1 extends any[]>(list1: L1) => [...L1, ...L2];
-export function concat<S2 extends string>(
-  placeholder: Placeholder,
-  s2: S2,
-): <S1 extends string>(s1: S1) => `${S1}${S2}`;
-export function concat<L1 extends any[]>(list1: L1): <L2 extends any[]>(list2: L2) => [...L1, ...L2];
+// concat(string)(string)
 export function concat<S1 extends string>(s1: S1): <S2 extends string>(s2: S2) => `${S1}${S2}`;
-export function concat<L1 extends any[], L2 extends any[]>(list1: L1, list2: L2): [...L1, ...L2];
+export function concat(s1: string): (s2: string) => string;
+// concat(list)(list)
+export function concat<L1 extends any[]>(list1: L1): <L2 extends any[]>(list2: L2) => [...L1, ...L2];
+// concat(__, string)(string)
+export function concat<S2 extends string>(__: Placeholder, s2: S2): <S1 extends string>(s1: S1) => `${S1}${S2}`;
+// concat(__, list)(list)
+export function concat<L2 extends any[]>(__: Placeholder,list2: L2): <L1 extends any[]>(list1: L1) => [...L1, ...L2];
+// concat(string, string)
 export function concat<S1 extends string, S2 extends string>(s1: S1, s2: S2): `${S1}${S2}`;
 export function concat(s1: string, s2: string): string;
-export function concat(s1: string): (s2: string) => string;
+// concat(list, list)
+export function concat<L1 extends any[], L2 extends any[]>(list1: L1, list2: L2): [...L1, ...L2];

--- a/types/concat.d.ts
+++ b/types/concat.d.ts
@@ -1,17 +1,14 @@
 import { Placeholder } from './util/tools';
 
 // concat(string)(string)
-export function concat<S1 extends string>(s1: S1): <S2 extends string>(s2: S2) => `${S1}${S2}`;
-export function concat(s1: string): (s2: string) => string;
+export function concat<S1 extends string>(s1: S1): <S2 extends string>(s2: S2) => string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(list)(list)
-export function concat<T>(list1: T[]): (list2: T[]) => T[];
+export function concat<T>(list1: readonly T[]): (list2: readonly T[]) => T[];
 // concat(__, string)(string)
-export function concat<S2 extends string>(__: Placeholder, s2: S2): <S1 extends string>(s1: S1) => `${S1}${S2}`;
-export function concat(__: Placeholder, s2: string): (s1: string) => string;
+export function concat<S2 extends string>(__: Placeholder, s2: S2): <S1 extends string>(s1: S1) => string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(__, list)(list)
-export function concat<T>(__: Placeholder, list2: T[]): (list1: T[]) => T[];
+export function concat<T>(__: Placeholder, list2: readonly T[]): (list1: readonly T[]) => T[];
 // concat(string, string)
-export function concat<S1 extends string, S2 extends string>(s1: S1, s2: S2): `${S1}${S2}`;
-export function concat(s1: string, s2: string): string;
+export function concat<S1 extends string, S2 extends string>(s1: S1, s2: S2): string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(list, list)
-export function concat<T>(list1: T[], list2: T[]): T[];
+export function concat<T>(list1: readonly T[], list2: readonly T[]): T[];

--- a/types/concat.d.ts
+++ b/types/concat.d.ts
@@ -1,14 +1,14 @@
-import { Placeholder } from './util/tools';
+import { Placeholder, WidenLiterals } from './util/tools';
 
 // concat(string)(string)
 export function concat<S1 extends string>(s1: S1): <S2 extends string>(s2: S2) => string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(list)(list)
-export function concat<T>(list1: readonly T[]): (list2: readonly T[]) => T[];
+export function concat<T>(list1: readonly T[]): (list2: readonly WidenLiterals<T>[]) => WidenLiterals<T>[];
 // concat(__, string)(string)
 export function concat<S2 extends string>(__: Placeholder, s2: S2): <S1 extends string>(s1: S1) => string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(__, list)(list)
-export function concat<T>(__: Placeholder, list2: readonly T[]): (list1: readonly T[]) => T[];
+export function concat<T>(__: Placeholder, list2: readonly T[]): (list1: readonly WidenLiterals<T>[]) => WidenLiterals<T>[];
 // concat(string, string)
 export function concat<S1 extends string, S2 extends string>(s1: S1, s2: S2): string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(list, list)
-export function concat<T>(list1: readonly T[], list2: readonly T[]): T[];
+export function concat<T>(list1: readonly T[], list2: readonly T[]): WidenLiterals<T>[];

--- a/types/concat.d.ts
+++ b/types/concat.d.ts
@@ -1,14 +1,14 @@
-import { Placeholder, WidenLiterals } from './util/tools';
+import { Placeholder } from './util/tools';
 
 // concat(string)(string)
 export function concat<S1 extends string>(s1: S1): <S2 extends string>(s2: S2) => string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(list)(list)
-export function concat<T>(list1: readonly T[]): (list2: readonly WidenLiterals<T>[]) => WidenLiterals<T>[];
+export function concat<T>(list1: readonly T[]): (list2: readonly T[]) => T[];
 // concat(__, string)(string)
 export function concat<S2 extends string>(__: Placeholder, s2: S2): <S1 extends string>(s1: S1) => string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(__, list)(list)
-export function concat<T>(__: Placeholder, list2: readonly T[]): (list1: readonly WidenLiterals<T>[]) => WidenLiterals<T>[];
+export function concat<T2>(__: Placeholder, list2: readonly T2[]): <T1>(list1: (readonly T2[] extends readonly T1[] ? readonly T1[] : never)) => T1[];
 // concat(string, string)
 export function concat<S1 extends string, S2 extends string>(s1: S1, s2: S2): string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(list, list)
-export function concat<T>(list1: readonly T[], list2: readonly T[]): WidenLiterals<T>[];
+export function concat<T1, T2 extends T1>(list1: readonly T1[], list2: readonly T2[]): T1[];

--- a/types/concat.d.ts
+++ b/types/concat.d.ts
@@ -1,5 +1,6 @@
 import { Placeholder } from './util/tools';
 
+// The array types are done in such a way to match native `Array#concat` behavior
 // concat(string)(string)
 export function concat<S1 extends string>(s1: S1): <S2 extends string>(s2: S2) => string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(list)(list)

--- a/types/concat.d.ts
+++ b/types/concat.d.ts
@@ -11,4 +11,5 @@ export function concat<T2>(__: Placeholder, list2: readonly T2[]): <T1>(list1: (
 // concat(string, string)
 export function concat<S1 extends string, S2 extends string>(s1: S1, s2: S2): string extends (S1 | S2) ? string : `${S1}${S2}`;
 // concat(list, list)
+// if you don't do 2 types here the single T will collapse list1 and list2 when you have tuples of the same type, which is incorrect behavior
 export function concat<T1, T2 extends T1>(list1: readonly T1[], list2: readonly T2[]): T1[];


### PR DESCRIPTION
This update aligns the type def for `concat` to match the native `Array#concat()` method. Specifically to disallow concatenation of arrays of different types. That existing type def for `concat` was not typesafe and it should have never been that

It also improves the types for concat on strings a bit