### PR TITLE
Fix: Map

### DIFF
--- a/types/map.d.ts
+++ b/types/map.d.ts
@@ -1,28 +1,28 @@
-import { FunctorMap, FunctorFantasyLand, Placeholder, ValueOfUnion, KeysOfUnion } from './util/tools';
+import { FunctorMap, FunctorFantasyLand, Placeholder, ValueOfUnion } from './util/tools';
 
 // map(fn)
-export function map<T, U>(fn: (x: T) => U): {
+export function map<A, B>(fn: (x: A) => B): {
   // first and last def are the same and are here on purpose
   // the list variant needs to come before the FunctorMap ones, because `T[]` is a `FunctorMap<T>`
-  (list: readonly T[]): U[];
-  (functor: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
-  (functor: FunctorMap<T>): FunctorMap<U>;
-  <O extends Record<PropertyKey, T>>(dict: O): Record<KeysOfUnion<O>, U>;
+  (list: readonly A[]): B[];
+  (functor: FunctorFantasyLand<A>): FunctorFantasyLand<B>;
+  (functor: FunctorMap<A>): FunctorMap<B>;
+  <U extends Record<PropertyKey, A>>(dict: U): Record<keyof U, B>;
   // it also needs to be here when you pass map as an argument to a function, eg `compose(map(fn))`
-  (list: readonly T[]): U[];
+  (list: readonly A[]): B[];
 };
 
 // map(__, list)
-export function map<T>(__: Placeholder, list: readonly T[]): <U>(fn: (x: T) => U) => U[];
+export function map<A>(__: Placeholder, list: readonly A[]): <B>(fn: (x: A) => B) => B[];
 export function map<A>(__: Placeholder, obj: FunctorFantasyLand<A>): <B>(fn: (a: A) => B) => FunctorFantasyLand<B>;
 export function map<A>(__: Placeholder, obj: FunctorMap<A>): <B>(fn: (a: A) => B) => FunctorMap<B>;
-export function map<O extends object>(__: Placeholder, dict: O): <U>(fn: (x: ValueOfUnion<O>) => U) => Record<KeysOfUnion<O>, U>;
+export function map<U extends object>(__: Placeholder, dict: U): <B>(fn: (x: ValueOfUnion<B>) => B) => Record<keyof U, B>;
 // map(fn, list)
 // first and last def are the same and are here on purpose
 // the list variant needs to come before the FunctorMap ones, because `T[]` is a `FunctorMap<T>`
-export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
-export function map<T, U>(fn: (x: T) => U, obj: FunctorFantasyLand<T>): FunctorFantasyLand<U>;
-export function map<T, U>(fn: (x: T) => U, obj: FunctorMap<T>): FunctorMap<U>;
-export function map<O extends object, U>(fn: (x: ValueOfUnion<O>) => U, dict: O): Record<KeysOfUnion<O>, U>;
+export function map<A, B>(fn: (x: A) => B, list: readonly A[]): B[];
+export function map<A, B>(fn: (x: A) => B, obj: FunctorFantasyLand<A>): FunctorFantasyLand<B>;
+export function map<A, B>(fn: (x: A) => B, obj: FunctorMap<A>): FunctorMap<B>;
+export function map<U extends object, B>(fn: (x: ValueOfUnion<U>) => B, dict: U): Record<keyof U, B>;
 // it also needs to be here when you pass map as an argument to a function, eg `flip(map)`
-export function map<T, U>(fn: (x: T) => U, list: readonly T[]): U[];
+export function map<A, B>(fn: (x: A) => B, list: readonly A[]): B[];

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -434,12 +434,6 @@ export type InputTypesOfFns<A extends ReadonlyArray<Fn>> = A extends [infer H, .
   : [];
 
 /**
- * When you have a union type, `keyof T` is not sufficient
- * <created by @harris-miller>
- */
-export type KeysOfUnion<T> = T extends infer U ? keyof U : never;
-
-/**
  * If `T` is a union, `T[keyof T]` (cf. `map` and `values` in `index.d.ts`) contains the types of object values that are common across the union (i.e., an intersection).
  * Because we want to include the types of all values, including those that occur in some, but not all members of the union, we first define `ValueOfUnion`.
  * @see https://stackoverflow.com/a/60085683


### PR DESCRIPTION
Map should not return `KeyOfUnion` when handling objects, it isn't typesafe. You don't know what keys the object will actually have. Just using `keyof U` will be the same keys as what is similar to the union types, which is what you get in typescript until you narrow the type