### PR TITLE
Update: keys related functions

### DIFF
--- a/test/fromPairs.test.ts
+++ b/test/fromPairs.test.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 
-import { fromPairs } from '../es';
+import { fromPairs, toPairs } from '../es';
 
 const symbolKey = Symbol('key');
 
@@ -12,3 +12,9 @@ expectType<{ foo: number; bar: number; 0: number; [symbolKey]: number; }>(fromPa
 expectType<{ [x: string]: number }>(fromPairs([] as [string, number][]));
 // 'foo' | 'bar' | string collapses to string, this is expected
 expectType<{ [x: string]: number }>(fromPairs([] as ['foo' | 'bar' | string, number][]));
+
+// should be able to go fromPairs -> toPairs and get original type back
+const pairs: (['foo', number] | ['bar', number])[] = [['foo', 1], ['bar', 2]];
+const obj = fromPairs(pairs);
+const backAgain = toPairs(obj);
+expectType<(['foo', number] | ['bar', number])[]>(backAgain);

--- a/test/fromPairs.test.ts
+++ b/test/fromPairs.test.ts
@@ -1,0 +1,12 @@
+import { expectType } from 'tsd';
+
+import { fromPairs } from '../es';
+
+// literals
+expectType<{ foo: number; bar: number }>(fromPairs([['foo', 1], ['bar', 2]]));
+// typed
+expectType<{ foo: number; bar: number }>(fromPairs([] as ['foo' | 'bar', number][]));
+// keys that are not a union of values produced an index signature type
+expectType<{ [x: string]: number }>(fromPairs([] as [string, number][]));
+// 'foo' | 'bar' | string collapses to string, this is expected
+expectType<{ [x: string]: number }>(fromPairs([] as ['foo' | 'bar' | string, number][]));

--- a/test/fromPairs.test.ts
+++ b/test/fromPairs.test.ts
@@ -2,10 +2,12 @@ import { expectType } from 'tsd';
 
 import { fromPairs } from '../es';
 
+const symbolKey = Symbol('key');
+
 // literals
-expectType<{ foo: number; bar: number }>(fromPairs([['foo', 1], ['bar', 2]]));
+expectType<{ foo: number; bar: number; }>(fromPairs([['foo', 1], ['bar', 2]]));
 // typed
-expectType<{ foo: number; bar: number }>(fromPairs([] as ['foo' | 'bar', number][]));
+expectType<{ foo: number; bar: number; 0: number; [symbolKey]: number; }>(fromPairs([] as ['foo' | 'bar' | 0 | typeof symbolKey, number][]));
 // keys that are not a union of values produced an index signature type
 expectType<{ [x: string]: number }>(fromPairs([] as [string, number][]));
 // 'foo' | 'bar' | string collapses to string, this is expected

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -1,0 +1,20 @@
+import { expectType } from 'tsd';
+
+import { keys } from '../es';
+
+type Obj = {
+  foo: string;
+  bar: string;
+};
+
+// empty object literal
+expectType<never[]>(keys({}));
+// type literal
+expectType<('foo' | 'bar')[]>(keys({ foo: '', bar: '' }));
+// typed object
+expectType<('foo' | 'bar')[]>(keys({} as Obj));
+// index signatures
+// for whatever reason, `keyof { [key: string]: string; }` returns `(string | number)[]`
+expectType<(string | number)[]>(keys({} as { [key: string]: string; }));
+// Record
+expectType<string[]>(keys({} as Record<string, string>));

--- a/test/toPairs.test.ts
+++ b/test/toPairs.test.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 
-import { toPairs } from '../es';
+import { fromPairs, toPairs } from '../es';
 
 type Obj = { 0: number; foo: string; bar: string; [symbolKey]: boolean; };
 
@@ -13,3 +13,9 @@ expectType<([0, number] | ['foo', string] | ['bar', string] | [typeof symbolKey,
 expectType<[string, number][]>(toPairs({} as { [index: string]: number }));
 // Record
 expectType<[string, number][]>(toPairs({} as Record<string, number>));
+
+// should be able to go toPair -> fromPair and get original type back
+const obj: { foo: number; bar: number } = { foo: 1, bar: 2 };
+const pairs = toPairs(obj);
+const backAgain = fromPairs(pairs);
+expectType<{ foo: number; bar: number }>(backAgain);

--- a/test/toPairs.test.ts
+++ b/test/toPairs.test.ts
@@ -1,0 +1,15 @@
+import { expectType } from 'tsd';
+
+import { toPairs } from '../es';
+
+type Obj = { 0: number; foo: string; bar: string; [symbolKey]: boolean; };
+
+const symbolKey = Symbol('key');
+// literals
+expectType<([0, number] | ['foo', string] | ['bar', string] | [typeof symbolKey, boolean])[]>(toPairs({} as { 0: number; foo: string; bar: string; [symbolKey]: boolean; }));
+// typed
+expectType<([0, number] | ['foo', string] | ['bar', string] | [typeof symbolKey, boolean])[]>(toPairs({} as Obj));
+// indexed objects
+expectType<[string, number][]>(toPairs({} as { [index: string]: number }));
+// Record
+expectType<[string, number][]>(toPairs({} as Record<string, number>));

--- a/types/fromPairs.d.ts
+++ b/types/fromPairs.d.ts
@@ -1,5 +1,3 @@
-import { KeyValuePair } from './util/tools';
-
-export function fromPairs<V>(
-  pairs: ReadonlyArray<Readonly<KeyValuePair<string, V>>> | ReadonlyArray<Readonly<KeyValuePair<number, V>>>,
-): { [index: string]: V };
+export function fromPairs<K extends string | number, V>(
+  pairs: readonly [K, V][]
+): { [P in K]: V };

--- a/types/fromPairs.d.ts
+++ b/types/fromPairs.d.ts
@@ -1,3 +1,3 @@
-export function fromPairs<K extends string | number, V>(
+export function fromPairs<K extends PropertyKey, V>(
   pairs: readonly [K, V][]
 ): { [P in K]: V };

--- a/types/keys.d.ts
+++ b/types/keys.d.ts
@@ -1,2 +1,1 @@
 export function keys<T extends object>(x: T): Array<keyof T>;
-export function keys<T>(x: T): string[];

--- a/types/toPairs.d.ts
+++ b/types/toPairs.d.ts
@@ -1,4 +1,3 @@
 export function toPairs<O extends object, K extends Extract<keyof O, string | number>>(
   obj: O,
 ): Array<{ [key in K]: [`${key}`, O[key]] }[K]>;
-export function toPairs<S>(obj: Record<string | number, S>): Array<[string, S]>;

--- a/types/toPairs.d.ts
+++ b/types/toPairs.d.ts
@@ -1,3 +1,1 @@
-export function toPairs<O extends object, K extends Extract<keyof O, string | number>>(
-  obj: O,
-): Array<{ [key in K]: [`${key}`, O[key]] }[K]>;
+export function toPairs<O extends object>(obj: O): Array<{ [key in keyof O]: [key, O[key]] }[keyof O]>;

--- a/types/toPairsIn.d.ts
+++ b/types/toPairsIn.d.ts
@@ -1,4 +1,1 @@
-export function toPairsIn<O extends object, K extends Extract<keyof O, string | number>>(
-  obj: O,
-): Array<{ [key in K]: [`${key}`, O[key]] }[K]>;
-export function toPairsIn<S>(obj: Record<string | number, S>): Array<[string, S]>;
+export function toPairsIn<S>(obj: Record<PropertyKey, S>): Array<[string, S]>;

--- a/types/toPairsIn.d.ts
+++ b/types/toPairsIn.d.ts
@@ -1,1 +1,1 @@
-export function toPairsIn<S>(obj: Record<PropertyKey, S>): Array<[string, S]>;
+export function toPairsIn<O extends object>(obj: O): Array<{ [key in keyof O]: [key, O[key]] }[keyof O]>;


### PR DESCRIPTION
Corrects the types for `keys`, `fromPairs`, `toPairs`, and `toPairsIn`