### PR TITLE
Update: Pick

### DIFF
--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -1,6 +1,6 @@
 import { expectType, expectError } from 'tsd';
 
-import { pick } from '../es';
+import { pick, KeysAsTuple } from '../es';
 
 const obj = { foo: 1, bar: '2', biz: false };
 
@@ -16,3 +16,9 @@ expectError(pick(['baz', 'bar', 'biz'], obj));
 
 // Record
 expectType<Record<string, number>>(pick(['foo', 'bar'], {} as Record<string, number>));
+
+const names: string[] = ['foo', 'bar'];
+// in cases where names is either `string[]` or `(keyof obj)[]`, cast with supplied `KeysAsTuple` type function
+expectType<typeof obj>(pick(names as KeysAsTuple<typeof obj>, obj));
+// this case however is inaccurate, best to cast as a `Partial` in a real-world scenario
+expectType<Partial<typeof obj>>(pick(names as KeysAsTuple<typeof obj>, obj) as Partial<typeof obj>);

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -1,0 +1,7 @@
+import { expectType } from 'tsd';
+
+import { pick } from '../es';
+
+const obj = { foo: 1, bar: '2', biz: false };
+
+expectType<{ foo: number, bar: string }>(pick(['foo', 'bar'], obj));

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -1,7 +1,18 @@
-import { expectType } from 'tsd';
+import { expectType, expectError } from 'tsd';
 
 import { pick } from '../es';
 
 const obj = { foo: 1, bar: '2', biz: false };
 
-expectType<{ foo: number, bar: string }>(pick(['foo', 'bar'], obj));
+expectType<{ foo: number; }>(pick(['foo'])(obj));
+expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'])(obj));
+expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'])(obj));
+expectError(pick(['baz', 'bar', 'biz'])(obj));
+
+expectType<{ foo: number; }>(pick(['foo'], obj));
+expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'], obj));
+expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'], obj));
+expectError(pick(['baz', 'bar', 'biz'], obj));
+
+// Record
+expectType<Record<string, number>>(pick(['foo', 'bar'], {} as Record<string, number>));

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -1,4 +1,4 @@
 import { ElementOf } from './util/tools';
 
 export function pick<const Names extends readonly [PropertyKey, ...PropertyKey[]]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : { [P in ElementOf<Names>]: U[P] };
-export function pick<U, Names extends readonly [keyof U, ...(keyof U)[]]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : { [P in ElementOf<Names>]: U[P] };
+export function pick<U, const Names extends readonly [keyof U, ...(keyof U)[]]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : { [P in ElementOf<Names>]: U[P] };

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -1,3 +1,4 @@
 import { ElementOf } from './util/tools';
 
-export function pick<U, Names extends [keyof U, ...(keyof U)[]]>(names: Names, obj: U): { [P in ElementOf<Names>]: U[P] };
+export function pick<const Names extends readonly [PropertyKey, ...PropertyKey[]]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : { [P in ElementOf<Names>]: U[P] };
+export function pick<U, Names extends readonly [keyof U, ...(keyof U)[]]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : { [P in ElementOf<Names>]: U[P] };

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -1,29 +1,3 @@
-import * as _ from 'ts-toolbelt';
+import { ElementOf } from './util/tools';
 
-export function pick<T extends readonly [any, ...any], K extends string | number | symbol>(
-  names: readonly K[],
-  array: T,
-): {
-  [P in K as P extends number
-    ? _.N.Greater<T['length'], P> extends 1
-      ? P
-      : never
-    : never]: P extends keyof T ? T[P] : T[number];
-};
-export function pick<T, K extends string | number | symbol>(
-  names: readonly K[],
-  obj: T,
-): { [P in keyof T as P extends K ? P : never]: T[P] };
-export function pick<K extends string | number | symbol>(
-  names: readonly K[],
-): <T extends readonly [any, ...any] | object>(
-  obj: T,
-) => T extends readonly [any, ...any]
-  ? {
-    [P in K as P extends number
-      ? _.N.Greater<T['length'], P> extends 1
-        ? P
-        : never
-      : never]: P extends keyof T ? T[P] : T[number];
-  }
-  : { [P in keyof T as P extends K ? P : never]: T[P] };
+export function pick<U, Names extends [keyof U, ...(keyof U)[]]>(names: Names, obj: U): { [P in ElementOf<Names>]: U[P] };

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -1,4 +1,5 @@
 import { ElementOf } from './util/tools';
 
-export function pick<const Names extends readonly [PropertyKey, ...PropertyKey[]]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : { [P in ElementOf<Names>]: U[P] };
-export function pick<U, const Names extends readonly [keyof U, ...(keyof U)[]]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : { [P in ElementOf<Names>]: U[P] };
+export function pick<const Names extends readonly [PropertyKey, ...PropertyKey[]]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
+export function pick<U, const Names extends readonly [keyof U, ...(keyof U)[]]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
+

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -500,3 +500,9 @@ export type WidenLiterals<T> =
       : T extends number
         ? number
         : T;
+
+/**
+ * Extract the types from an array
+ * Works with Tuples, eg `ElementOf<typeof ['p1', 'p2']>` => `'p1' | 'p2'`
+ */
+export type ElementOf<Type extends readonly any[]> = Type extends readonly (infer Values)[] ? Values : never;

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -504,5 +504,14 @@ export type WidenLiterals<T> =
 /**
  * Extract the types from an array
  * Works with Tuples, eg `ElementOf<typeof ['p1', 'p2']>` => `'p1' | 'p2'`
+ *
+ * <created by @harris-miller>
  */
 export type ElementOf<Type extends readonly any[]> = Type extends readonly (infer Values)[] ? Values : never;
+
+/**
+ * Convenance type function to extract keys of an object as a tuple literal
+ *
+ * <created by @harris-miller>
+ */
+export type KeysAsTuple<T> = [keyof T, ...(keyof T)[]];


### PR DESCRIPTION
Previous definition were not type-safe, playground explanation: https://tsplay.dev/wQJRjN

New definition strictly allows only a tuple of the keys for the obj it is picking from

