### PR TITLE
Fix: allPass, anyPass, both, either, ifElse 

### DIFF
--- a/test/anyPass.test.ts
+++ b/test/anyPass.test.ts
@@ -25,7 +25,7 @@ expectType<boolean>(
   })
 );
 
-expectType<boolean>(
+expectError(
   isVampire({
     age: 21,
     garlic_allergy: true,

--- a/test/anyPass.test.ts
+++ b/test/anyPass.test.ts
@@ -1,0 +1,50 @@
+import { expectType, expectError } from 'tsd';
+import { anyPass, propEq } from '../es';
+
+const isOld = propEq(212, 'age');
+const isAllergicToGarlic = propEq(true, 'garlic_allergy');
+const isAllergicToSun = propEq(true, 'sun_allergy');
+const isFast = propEq(null, 'fast');
+const isAfraid = propEq(undefined, 'fear');
+
+const isVampire = anyPass([
+  isOld,
+  isAllergicToGarlic,
+  isAllergicToSun,
+  isFast,
+  isAfraid
+]);
+
+expectType<boolean>(
+  isVampire({
+    age: 212,
+    garlic_allergy: true,
+    sun_allergy: true,
+    fast: null,
+    fear: undefined
+  })
+);
+
+expectType<boolean>(
+  isVampire({
+    age: 21,
+    garlic_allergy: true,
+    sun_allergy: true,
+    fast: false,
+    fear: true
+  })
+);
+
+expectError(
+  isVampire({
+    age: 40,
+    garlic_allergy: true,
+    fear: false
+  })
+);
+
+expectError(
+  isVampire({
+    nickname: 'Blade'
+  })
+);

--- a/test/both.test.ts
+++ b/test/both.test.ts
@@ -1,0 +1,23 @@
+import { expectType, expectError } from 'tsd';
+
+import { both } from '../es';
+
+const gt10 = (x: number) => x > 10;
+const lt20 = (x: number) => x < 20;
+
+const isEmptyString = (x: string) => x === '';
+
+expectType<(x: number) => boolean>(both(gt10, lt20));
+expectError(both(gt10, isEmptyString));
+expectError(both(isEmptyString, lt20));
+
+expectType<(x: number) => boolean>(both(gt10)(lt20));
+expectError(both(gt10)(isEmptyString));
+expectError(both(isEmptyString)(lt20));
+
+// contrived functions for sake of testing
+const is1To3 = (x: number): x is 1 | 2 | 3 => true;
+const is2To5 = (x: number): x is 2 | 3 | 4 | 5 => true;
+
+expectType<(x: number) => 2 | 3>(both(is1To3, is2To5));
+expectType<(x: number) => 2 | 3>(both(is1To3)(is2To5));

--- a/test/both.test.ts
+++ b/test/both.test.ts
@@ -21,3 +21,10 @@ const is2To5 = (x: number): x is 2 | 3 | 4 | 5 => true;
 
 expectType<(x: number) => 2 | 3>(both(is1To3, is2To5));
 expectType<(x: number) => 2 | 3>(both(is1To3)(is2To5));
+
+// 2+ arity
+const areBothGt10 = (x: number, y: number) => x > 10 && y > 10;
+const areBothLt20 = (x: number, y: number) => x < 20 && y < 20;
+
+expectType<(x: number, y: number) => boolean>(both(areBothGt10, areBothLt20));
+expectType<(x: number, y: number) => boolean>(both(areBothGt10)(areBothLt20));

--- a/test/both.test.ts
+++ b/test/both.test.ts
@@ -19,8 +19,8 @@ expectError(both(isEmptyString)(lt20));
 const is1To3 = (x: number): x is 1 | 2 | 3 => true;
 const is2To5 = (x: number): x is 2 | 3 | 4 | 5 => true;
 
-expectType<(x: number) => 2 | 3>(both(is1To3, is2To5));
-expectType<(x: number) => 2 | 3>(both(is1To3)(is2To5));
+expectType<(x: number) => x is 2 | 3>(both(is1To3, is2To5));
+expectType<(x: number) => x is 2 | 3>(both(is1To3)(is2To5));
 
 // 2+ arity
 const areBothGt10 = (x: number, y: number) => x > 10 && y > 10;

--- a/test/either.test.ts
+++ b/test/either.test.ts
@@ -1,0 +1,23 @@
+import { expectType, expectError } from 'tsd';
+
+import { either } from '../es';
+
+const lt10 = (x: number) => x < 10;
+const gt20 = (x: number) => x > 20;
+
+const isEmptyString = (x: string) => x === '';
+
+expectType<(x: number) => boolean>(either(lt10, gt20));
+expectError(either(lt10, isEmptyString));
+expectError(either(isEmptyString, gt20));
+
+expectType<(x: number) => boolean>(either(lt10)(gt20));
+expectError(either(lt10)(isEmptyString));
+expectError(either(isEmptyString)(gt20));
+
+// 2+ arity
+const areBothLt10 = (x: number, y: number) => x < 10 && y < 10;
+const areBothGt20 = (x: number, y: number) => x > 20 && y > 20;
+
+expectType<(x: number, y: number) => boolean>(either(areBothLt10, areBothGt20));
+expectType<(x: number, y: number) => boolean>(either(areBothLt10)(areBothGt20));

--- a/test/ifElse.test.ts
+++ b/test/ifElse.test.ts
@@ -1,0 +1,33 @@
+import { expectType, expectError } from 'tsd';
+
+import { ifElse } from '../es';
+
+type Foo = {
+  type: 'foo',
+  str: string;
+};
+
+type Bar = {
+  type: 'bar',
+  num: number;
+};
+
+type FooOrBar = Foo | Bar;
+
+const isFoo = (x: FooOrBar): x is Foo => x.type === 'foo';
+const isBar = (x: FooOrBar): x is Bar => x.type === 'bar';
+
+expectType<(x: FooOrBar) => string | number>(ifElse(isFoo, (x: Foo) => x.str, (x: Bar) => x.num));
+expectType<(x: FooOrBar) => number | string>(ifElse(isBar, (x: Bar) => x.num, (x: Foo) => x.str));
+
+// unary
+const lt10 = (x: number) => x < 10;
+expectType<(x: number) => string>(ifElse(lt10, (x: number) => 'lt10', (x: number) => 'gte10'));
+// different return types are ok
+expectType<(x: number) => string | number>(ifElse(lt10, (x: number) => '', (x: number) => 0));
+// different argument types are not
+expectError(ifElse(lt10, (x: number) => '', (x: string) => ''));
+
+// binary
+const areBothGt10 = (x: number, y: number) => x > 10 && y > 10;
+expectType<(x: number, y: number) => string>(ifElse(areBothGt10, (x: number, y: number) => 'lt10', (x: number, y: number) => 'gte10'));

--- a/types/allPass.d.ts
+++ b/types/allPass.d.ts
@@ -1,34 +1,29 @@
-import { PredTypeguard, Pred } from './util/tools';
-
 export function allPass<T, TF1 extends T, TF2 extends T>(
-  preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2]
 ): (a: T) => a is TF1 & TF2;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>],
-): (a: T) => a is TF1 & TF2 & TF3;
-export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
 ): (a: T) => a is TF1 & TF2 & TF3;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T>(
-  preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>, PredTypeguard<T, TF4>],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3, (a: T) => a is TF4],
 ): (a: T) => a is TF1 & TF2 & TF3 & TF4;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T>(
-  preds: [
-    PredTypeguard<T, TF1>,
-    PredTypeguard<T, TF2>,
-    PredTypeguard<T, TF3>,
-    PredTypeguard<T, TF4>,
-    PredTypeguard<T, TF5>
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2,
+    (a: T) => a is TF3,
+    (a: T) => a is TF4,
+    (a: T) => a is TF5
   ],
-): PredTypeguard<T, TF1 & TF2 & TF3 & TF4 & TF5>;
+): (a: T) => TF1 & TF2 & TF3 & TF4 & TF5;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T, TF6 extends T>(
-  preds: [
-    PredTypeguard<T, TF1>,
-    PredTypeguard<T, TF2>,
-    PredTypeguard<T, TF3>,
-    PredTypeguard<T, TF4>,
-    PredTypeguard<T, TF5>,
-    PredTypeguard<T, TF6>
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2,
+    (a: T) => a is TF3,
+    (a: T) => a is TF4,
+    (a: T) => a is TF5,
+    (a: T) => a is TF6
   ],
-): PredTypeguard<T, TF1 & TF2 & TF3 & TF4 & TF5 & TF6>;
-export function allPass<F extends Pred>(preds: readonly F[]): F;
+): (a: T) => TF1 & TF2 & TF3 & TF4 & TF5 & TF6;
+export function allPass<F extends (...args: any[]) => boolean>(predicates: readonly F[]): F;

--- a/types/allPass.d.ts
+++ b/types/allPass.d.ts
@@ -15,7 +15,7 @@ export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 exte
     (a: T) => a is TF4,
     (a: T) => a is TF5
   ],
-): (a: T) => TF1 & TF2 & TF3 & TF4 & TF5;
+): (a: T) => a is TF1 & TF2 & TF3 & TF4 & TF5;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T, TF6 extends T>(
   predicates: [
     (a: T) => a is TF1,
@@ -25,5 +25,5 @@ export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 exte
     (a: T) => a is TF5,
     (a: T) => a is TF6
   ],
-): (a: T) => TF1 & TF2 & TF3 & TF4 & TF5 & TF6;
+): (a: T) => a is TF1 & TF2 & TF3 & TF4 & TF5 & TF6;
 export function allPass<F extends (...args: any[]) => boolean>(predicates: readonly F[]): F;

--- a/types/anyPass.d.ts
+++ b/types/anyPass.d.ts
@@ -18,7 +18,7 @@ export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 exte
     (a: T) => a is TF4,
     (a: T) => a is TF5
   ],
-): (a: T) => TF1 | TF2 | TF3 | TF4 | TF5;
+): (a: T) => a is TF1 | TF2 | TF3 | TF4 | TF5;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T, TF6 extends T>(
   predicates: [
     (a: T) => a is TF1,
@@ -28,5 +28,5 @@ export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 exte
     (a: T) => a is TF5,
     (a: T) => a is TF6
   ],
-): (a: T) => TF1 | TF2 | TF3 | TF4 | TF5 | TF6;
+): (a: T) => a is TF1 | TF2 | TF3 | TF4 | TF5 | TF6;
 export function anyPass<F extends (...args: any[]) => boolean>(predicates: readonly F[]): F;

--- a/types/anyPass.d.ts
+++ b/types/anyPass.d.ts
@@ -1,34 +1,32 @@
-import { PredTypeguard, Pred } from './util/tools';
-
 export function anyPass<T, TF1 extends T, TF2 extends T>(
-  preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2],
 ): (a: T) => a is TF1 | TF2;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
 ): (a: T) => a is TF1 | TF2 | TF3;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
 ): (a: T) => a is TF1 | TF2 | TF3;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T>(
-  preds: [PredTypeguard<T, TF1>, PredTypeguard<T, TF2>, PredTypeguard<T, TF3>, PredTypeguard<T, TF4>],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3, (a: T) => a is TF4],
 ): (a: T) => a is TF1 | TF2 | TF3 | TF4;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T>(
-  preds: [
-    PredTypeguard<T, TF1>,
-    PredTypeguard<T, TF2>,
-    PredTypeguard<T, TF3>,
-    PredTypeguard<T, TF4>,
-    PredTypeguard<T, TF5>
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2,
+    (a: T) => a is TF3,
+    (a: T) => a is TF4,
+    (a: T) => a is TF5
   ],
-): PredTypeguard<T, TF1 | TF2 | TF3 | TF4 | TF5>;
+): (a: T) => TF1 | TF2 | TF3 | TF4 | TF5;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T, TF6 extends T>(
-  preds: [
-    PredTypeguard<T, TF1>,
-    PredTypeguard<T, TF2>,
-    PredTypeguard<T, TF3>,
-    PredTypeguard<T, TF4>,
-    PredTypeguard<T, TF5>,
-    PredTypeguard<T, TF6>
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2,
+    (a: T) => a is TF3,
+    (a: T) => a is TF4,
+    (a: T) => a is TF5,
+    (a: T) => a is TF6
   ],
-): PredTypeguard<T, TF1 | TF2 | TF3 | TF4 | TF5 | TF6>;
-export function anyPass<F extends Pred>(preds: readonly F[]): F;
+): (a: T) => TF1 | TF2 | TF3 | TF4 | TF5 | TF6;
+export function anyPass<F extends (...args: any[]) => boolean>(predicates: readonly F[]): F;

--- a/types/both.d.ts
+++ b/types/both.d.ts
@@ -1,6 +1,6 @@
 // both(f)(g) => (x: T) => boolean
 export function both<T, RT1 extends T>(f: (a: T) => a is RT1): <RT2 extends T>(g: (b: T) => b is RT2) => (x: T) => RT1 & RT2;
-export function both<T>(f: (a: T) => boolean): (g: (b: T) => boolean) => (x: T) => boolean;
+export function both<Args extends any[]>(f: (...args: Args) => boolean): (g: (...rgs: Args) => boolean) => (...args: Args) => boolean;
 // both(f, g) => (x: T) => boolean
 export function both<T, RT1 extends T, RT2 extends T>(f: (a: T) => a is RT1, g: (b: T) => b is RT2): (x: T) => RT1 & RT2;
-export function both<T>(f: (a: T) => boolean, g: (b: T) => boolean): (x: T) => boolean;
+export function both<Args extends any[]>(f: (...args: Args) => boolean, g: (...args: Args) => boolean): (...args: Args) => boolean;

--- a/types/both.d.ts
+++ b/types/both.d.ts
@@ -1,6 +1,6 @@
 // both(f)(g) => (x: T) => boolean
-export function both<T, RT1 extends T>(f: (a: T) => a is RT1): <RT2 extends T>(g: (b: T) => b is RT2) => (x: T) => RT1 & RT2;
-export function both<Args extends any[]>(f: (...args: Args) => boolean): (g: (...rgs: Args) => boolean) => (...args: Args) => boolean;
+export function both<T, RT1 extends T>(f: (a: T) => a is RT1): <RT2 extends T>(g: (a: T) => a is RT2) => (a: T) => a is RT1 & RT2;
+export function both<Args extends any[]>(f: (...args: Args) => boolean): (g: (...args: Args) => boolean) => (...args: Args) => boolean;
 // both(f, g) => (x: T) => boolean
-export function both<T, RT1 extends T, RT2 extends T>(f: (a: T) => a is RT1, g: (b: T) => b is RT2): (x: T) => RT1 & RT2;
+export function both<T, RT1 extends T, RT2 extends T>(f: (a: T) => a is RT1, g: (a: T) => a is RT2): (a: T) => a is RT1 & RT2;
 export function both<Args extends any[]>(f: (...args: Args) => boolean, g: (...args: Args) => boolean): (...args: Args) => boolean;

--- a/types/both.d.ts
+++ b/types/both.d.ts
@@ -1,8 +1,6 @@
-import { PredTypeguard, Pred } from './util/tools';
-
-export function both<T extends Pred>(pred1: T): (pred2: T) => T;
-export function both<T, TF1 extends T, TF2 extends T>(
-  pred1: PredTypeguard<T, TF1>,
-  pred2: PredTypeguard<T, TF2>,
-): (a: T) => a is TF1 & TF2;
-export function both<T extends Pred>(pred1: T, pred2: T): T;
+// both(f)(g) => (x: T) => boolean
+export function both<T, RT1 extends T>(f: (a: T) => a is RT1): <RT2 extends T>(g: (b: T) => b is RT2) => (x: T) => RT1 & RT2;
+export function both<T>(f: (a: T) => boolean): (g: (b: T) => boolean) => (x: T) => boolean;
+// both(f, g) => (x: T) => boolean
+export function both<T, RT1 extends T, RT2 extends T>(f: (a: T) => a is RT1, g: (b: T) => b is RT2): (x: T) => RT1 & RT2;
+export function both<T>(f: (a: T) => boolean, g: (b: T) => boolean): (x: T) => boolean;

--- a/types/either.d.ts
+++ b/types/either.d.ts
@@ -1,4 +1,2 @@
-import { Pred } from './util/tools';
-
-export function either<T extends Pred>(pred1: T): (pred2: T) => T;
-export function either<T extends Pred>(pred1: T, pred2: T): T;
+export function either<Fn extends (...args: any[]) => boolean>(f: Fn): (g: Fn) => Fn;
+export function either<Fn extends (...args: any[]) => boolean>(f: Fn, g: Fn): Fn;

--- a/types/ifElse.d.ts
+++ b/types/ifElse.d.ts
@@ -1,12 +1,10 @@
-import { PredTypeguard, Pred } from './util/tools';
-
 export function ifElse<T, TF extends T, TOnTrueResult, TOnFalseResult>(
-  pred: PredTypeguard<T, TF>,
+  pred: (a: T) => a is TF,
   onTrue: (a: TF) => TOnTrueResult,
   onFalse: (a: Exclude<T, TF>) => TOnFalseResult,
 ): (a: T) => TOnTrueResult | TOnFalseResult;
-export function ifElse<TArgs extends any[], TOnTrueResult, TOnFalseResult>(
-  fn: Pred<TArgs>,
+export function ifElse<TArgs extends readonly any[], TOnTrueResult, TOnFalseResult>(
+  fn: (...args: TArgs) => boolean,
   onTrue: (...args: TArgs) => TOnTrueResult,
   onFalse: (...args: TArgs) => TOnFalseResult,
 ): (...args: TArgs) => TOnTrueResult | TOnFalseResult;

--- a/types/propEq.d.ts
+++ b/types/propEq.d.ts
@@ -2,5 +2,5 @@ export function propEq<T>(val: T): {
   <K extends PropertyKey>(name: K): (obj: Record<K, T>) => boolean;
   <K extends PropertyKey>(name: K, obj: Record<K, T>): boolean;
 };
-export function propEq<T, K extends PropertyKey>(val: T, name: K): (obj:  Record<K, T>) => boolean;
+export function propEq<T, K extends PropertyKey>(val: T, name: K): (obj: Record<K, T>) => boolean;
 export function propEq<K extends keyof U, U>(val: U[K], name: K, obj: U): boolean;

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -375,29 +375,6 @@ export type Path = Array<number | string>;
 export type Placeholder = A.x & { '@@functional/placeholder': true };
 
 /**
- * Takes a lists of arguments and returns either `true` or `false`.
- *
- * Classical predicates only take one argument, but since ramda
- * supports multiple arguments, we also use them like that.
- *
- * Note that these predicates, don't represent typeguards,
- * meaning when this type is used, we can't get type narrowing.
- *
- * @see {@link PredTypeguard} for the typeguard version of this.
- */
-export type Pred<T extends any[] = any[]> = (...a: T) => boolean;
-
-/**
- * Takes an argument and returns either `true` or `false`.
- *
- * This is usually used as an overload before {@link Pred}.
- * If you would this type alone, the function would **required**
- * to be a typeguard, meaning a simple function just returning
- * a `boolean` wouldn't satisfy this constrain.
- */
-export type PredTypeguard<T, TTypeguarded extends T> = (a: T) => a is TTypeguarded;
-
-/**
  * A runtime-branded value used to stop `reduce` and `transduce` early.
  * @param A The type of the contained value
  */


### PR DESCRIPTION
Removing usage of `Pred` and`PredTypeguard`. Using inline definitions gives better error messages

```typescript
const gt10 = (x: number) => x > 10;
const lt20 = (x: number) => x < 20;

const isEmptyString = (x: string) => x === '';

both(gt10, isEmptyString); // type-error

// previous:
// Argument of type '(x: number) => boolean' is not assignable to parameter of type 'PredTypeguard<number, number>'
// ^^ This argument doesn't really tell you what is wrong, since the type `PredTypeguard` is hidden

// new:
// Argument of type '(x: number) => boolean' is not assignable to parameter of type '(a: number) => a is number'
// ^^ Using literals in the definition gives a more direct error message that's easier to understand
```