### PR TITLE
Fix: Random Fixes

### DIFF
--- a/types/remove.d.ts
+++ b/types/remove.d.ts
@@ -1,6 +1,6 @@
-export function remove<T>(start: number): {
-  (count: number, list: readonly T[]): T[];
-  (count: number): (list: readonly T[]) => T[];
+export function remove(start: number): {
+  (count: number): <T>(list: readonly T[]) => T[];
+  <T>(count: number, list: readonly T[]): T[];
 };
-export function remove<T>(start: number, count: number): (list: readonly T[]) => T[];
+export function remove(start: number, count: number): <T>(list: readonly T[]) => T[];
 export function remove<T>(start: number, count: number, list: readonly T[]): T[];

--- a/types/reverse.d.ts
+++ b/types/reverse.d.ts
@@ -1,2 +1,2 @@
-export function reverse<T>(list: readonly T[]): T[];
 export function reverse(str: string): string;
+export function reverse<T>(list: readonly T[]): T[];

--- a/types/slice.d.ts
+++ b/types/slice.d.ts
@@ -1,13 +1,13 @@
 export function slice(a: number): {
-  <T>(b: number, list: readonly T[]): T[];
   (b: number, list: string): string;
+  <T>(b: number, list: readonly T[]): T[];
 };
 export function slice(
   a: number,
   b: number,
 ): {
-  <T>(list: readonly T[]): T[];
   (list: string): string;
+  <T>(list: readonly T[]): T[];
 };
 export function slice(a: number, b: number, list: string): string;
 export function slice<T>(a: number, b: number, list: readonly T[]): T[];

--- a/types/take.d.ts
+++ b/types/take.d.ts
@@ -2,5 +2,5 @@ export function take(n: number): {
   (xs: string): string;
   <T>(xs: readonly T[]): T[];
 };
-export function take<T>(n: number, xs: readonly T[]): T[];
 export function take(n: number, xs: string): string;
+export function take<T>(n: number, xs: readonly T[]): T[];

--- a/types/transduce.d.ts
+++ b/types/transduce.d.ts
@@ -1,11 +1,5 @@
 export function transduce<T, U, V>(
   xf: (arg: readonly T[]) => U[],
-  fn: (acc: V, val: U) => V,
-  acc: V,
-  list: readonly T[],
-): V;
-export function transduce<T, U, V>(
-  xf: (arg: readonly T[]) => U[],
 ): (fn: (acc: V, val: U) => V, acc: V, list: readonly T[]) => V;
 export function transduce<T, U, V>(
   xf: (arg: readonly T[]) => U[],
@@ -16,3 +10,9 @@ export function transduce<T, U, V>(
   fn: (acc: V, val: U) => V,
   acc: readonly T[],
 ): (list: readonly T[]) => V;
+export function transduce<T, U, V>(
+  xf: (arg: readonly T[]) => U[],
+  fn: (acc: V, val: U) => V,
+  acc: V,
+  list: readonly T[],
+): V;

--- a/types/values.d.ts
+++ b/types/values.d.ts
@@ -1,3 +1,3 @@
 import { ValueOfUnion } from './util/tools';
 
-export function values<T extends object, K extends keyof T>(obj: T): Array<T[K] | ValueOfUnion<T>>;
+export function values<T extends object>(obj: T): ValueOfUnion<T>[];


### PR DESCRIPTION
Just some random fixes for things that were more general and could be dumped into a single PR

* Simplify the types for `values`
* Fix overload ordering for `slice`
* fix overload ordering for `reverse`
* fix placement of the generic for `placement`
* fix overload ordering for `take`
* fix overload ordering for `tranduce`