### PR TITLE
Update: add 'AsyncFunction' to return type union of `type`

### DIFF
--- a/types/type.d.ts
+++ b/types/type.d.ts
@@ -1,6 +1,4 @@
-export function type(
-  val: any,
-):
+export function type(val: any):
 | 'Object'
 | 'Number'
 | 'Boolean'
@@ -9,6 +7,7 @@ export function type(
 | 'Array'
 | 'RegExp'
 | 'Function'
+| 'AsyncFunction'
 | 'Undefined'
 | 'Symbol'
 | 'Error'


### PR DESCRIPTION
`R.type(async () => {});` returns `'AsyncFunction'`, which was not part of the return union