### PR TITLE
Update: match

### DIFF
--- a/test/match.test.ts
+++ b/test/match.test.ts
@@ -1,0 +1,8 @@
+import { expectType } from 'tsd';
+
+import { __, match } from '../es';
+
+// not much to test here
+expectType<RegExpMatchArray>(match(/foo/, 'foo'));
+expectType<RegExpMatchArray>(match(/foo/)('foo'));
+expectType<RegExpMatchArray>(match(__, 'foo')(/foo/));

--- a/types/match.d.ts
+++ b/types/match.d.ts
@@ -1,2 +1,7 @@
-export function match(regexp: RegExp): (str: string) => string[];
-export function match(regexp: RegExp, str: string): string[];
+import { Placeholder } from './util/tools';
+
+// ramda used `Array.prototype.match` in its implementation, but never returns undefined
+// See: https://github.com/ramda/ramda/blob/v0.29.1/source/match.js#L26
+export function match(regexp: RegExp): (str: string) => RegExpMatchArray;
+export function match(__: Placeholder, str: string): (regexp: RegExp) => RegExpMatchArray;
+export function match(regexp: RegExp, str: string): RegExpMatchArray;


### PR DESCRIPTION
Correct typing for `match`, including currying