### PR TITLE
Update: support modifyPath change from 0.29.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dox": "^1.0.0",
         "eslint": "^8.50.0",
         "eslint-plugin-import": "^2.28.1",
-        "ramda": "^0.29.0",
+        "ramda": "^0.29.1",
         "tsd": "^0.29.0",
         "typescript": "^5.2.2",
         "xyz": "^4.0.0"
@@ -2902,9 +2902,9 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.1.tgz",
+      "integrity": "sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5761,9 +5761,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.1.tgz",
+      "integrity": "sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==",
       "dev": true
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "dox": "^1.0.0",
     "eslint": "^8.50.0",
     "eslint-plugin-import": "^2.28.1",
-    "ramda": "^0.29.0",
+    "ramda": "^0.29.1",
     "tsd": "^0.29.0",
     "typescript": "^5.2.2",
     "xyz": "^4.0.0"

--- a/test/modifyPath.test.ts
+++ b/test/modifyPath.test.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectType } from 'tsd';
-import { modifyPath, reverse, identity } from '../es';
+import { append, modifyPath, reverse, identity } from '../es';
 
 // test paths 1 to 7
 // with string -> number
@@ -14,6 +14,9 @@ type T4 = { t0: string; d0: { t1: string, d1: { t2: string, d2: { t3: string, d3
 type T5 = { t0: string; d0: { t1: string, d1: { t2: string, d2: { t3: string, d3: { t4: string, d4: { t5: string } } } } } };
 type T6 = { t0: string; d0: { t1: string, d1: { t2: string, d2: { t3: string, d3: { t4: string, d4: { t5: string, d5: { t6: string } } } } } } };
 type T7 = { t0: string; d0: { t1: string, d1: { t2: string, d2: { t3: string, d3: { t4: string, d4: { t5: string, d5: { t6: string, d6: { t7: string } } } } } } } };
+
+// 0.29.1 supports passing an empty array as the first arg, in which the modify function acts direction on the subject
+expectType<string[]>(modifyPath([], append('foo'), [] as string[]));
 
 expectAssignable<
 { t0: number }

--- a/types/modifyPath.d.ts
+++ b/types/modifyPath.d.ts
@@ -1,6 +1,7 @@
 import { DeepModify } from './util/deepModify';
 import { Path } from './util/tools';
 
+export function modifyPath<U, T>(path: [], fn: (value: U) => T, obj: U): T;
 export function modifyPath<K0 extends keyof U, U, T>(path: [K0], fn: (value: U[K0]) => T, obj: U): DeepModify<[K0], U, T>;
 export function modifyPath<
   K0 extends keyof U,


### PR DESCRIPTION
`modifyPath` now supports passing empty array in first arg, this update adds support for that