### PR TITLE
fix(pluck): pluck now can return object

### DIFF
--- a/test/pluck.test.ts
+++ b/test/pluck.test.ts
@@ -3,108 +3,86 @@ import { expectType, expectError } from 'tsd';
 import { __, pluck } from '../es';
 
 type Obj = { name: string; age: number };
-
-const record = {
-  a: {name: 'foo', age: 13},
-  b: {name: 'bar', age: 31, desc: 'barrr'}
+type Rec = {
+  a: {name: string, age: number},
+  b: {name: string, age: number, desc: string}
 };
-const constRecord = {
-  a: {name: 'foo', age: 13},
-  b: {name: 'bar', age: 31, desc: 'barrr'}
-} as const;
-const incorrectRecord = {
-  a: {name: 'foo', age: 13},
-  b: {name: 'bar', age: 31, desc: 'barrr'},
-  c: {}
+type ConstRec = {
+  readonly a: {name: 'foo', age: 13},
+  readonly b: {name: 'bar', age: 31, desc: 'barrr'}
 };
 
 // pluck(key)
-{
-  const getFirstItems = pluck(0);
-  const getName = pluck('name');
-  const getAge = pluck('age');
-  const getNope = pluck('nope');
+const getFirstItems = pluck(0);
+const getName = pluck('name');
+const getAge = pluck('age');
+const getNope = pluck('nope');
 
-  // pluck(key)(list::Array[])
-  {
-    expectType<string[]>(getFirstItems([] as string[][]));
-    expectType<number[]>(getFirstItems([] as number[][]));
-    expectType<1[]>(getFirstItems([] as 1[][]));
-    expectType<Obj[]>(getFirstItems([] as Obj[][]));
-    expectError(getFirstItems('string')); // works in JS, but should not be valid in TS
-    expectError(getFirstItems({} as Obj));
-  }
+// pluck(key)(list::Array[])
+expectType<string[]>(getFirstItems([] as string[][]));
+expectType<number[]>(getFirstItems([] as number[][]));
+expectType<1[]>(getFirstItems([] as 1[][]));
+expectType<Obj[]>(getFirstItems([] as Obj[][]));
+expectError(getFirstItems('string')); // works in JS, but should not be valid in TS
+expectError(getFirstItems({} as Obj));
 
-  // pluck(key)(list::Record[])
-  {
-    expectType<string[]>(getName([] as Obj[]));
-    expectType<number[]>(getAge([] as Obj[]));
-    expectError(getNope([] as Obj[]));
-    expectError(getFirstItems([] as Obj[]));
-  }
 
-  // pluck(key)(record::Record)
-  {
-    expectType<{ a: string, b: string }>(getName(record));
-    expectType<{ a: number, b: number }>(getAge(record));
-    expectType<{ readonly a: 'foo', readonly b: 'bar' }>(getName(constRecord));
-    expectError(getNope(record));
-    expectError(getAge(incorrectRecord));
-    // expectType<{ readonly a: undefined, readonly b: 'barrr' }>(pluck('desc')(constRecord));
-    // this ^ gives false negative result, but it can't be fixed right now
-  }
-}
+// pluck(key)(list::Record[])
+expectType<string[]>(getName([] as Obj[]));
+expectType<number[]>(getAge([] as Obj[]));
+expectError(getNope([] as Obj[]));
+expectError(getFirstItems([] as Obj[]));
+
+
+// pluck(key)(record::Record)
+expectType<{ a: string, b: string }>(getName({} as Rec));
+expectType<{ a: number, b: number }>(getAge({} as Rec));
+expectType<{ readonly a: 'foo', readonly b: 'bar' }>(getName({} as ConstRec));
+expectError(getNope({} as Rec));
+expectError(pluck('desc')({} as ConstRec)); // works in JS, but not valid in TS
+
 
 // pluck(key, list::Record[])
-{
-  expectType<string[]>(pluck('name', [] as Obj[]));
-  expectType<number[]>(pluck('age', [] as Obj[]));
-  expectError(pluck('nope', [] as Obj[]));
-  expectError(pluck(0, [] as Obj[]));
-}
+expectType<string[]>(pluck('name', [] as Obj[]));
+expectType<number[]>(pluck('age', [] as Obj[]));
+expectError(pluck('nope', [] as Obj[]));
+expectError(pluck(0, [] as Obj[]));
+
 
 // pluck(key, list::Array[])
-{
-  expectType<string[]>(pluck(0, [] as string[][]));
-  expectType<number[]>(pluck(1, [] as number[][]));
-  expectType<1[]>(pluck(0, [] as 1[][]));
-  expectType<Obj[]>(pluck(0, [] as Obj[][]));
-  expectError(pluck(0, 'string')); // works in JS, but should not be valid in TS
-  expectError(pluck(0, {} as Obj));
-}
+expectType<string[]>(pluck(0, [] as string[][]));
+expectType<number[]>(pluck(1, [] as number[][]));
+expectType<1[]>(pluck(0, [] as 1[][]));
+expectType<Obj[]>(pluck(0, [] as Obj[][]));
+expectError(pluck(0, 'string')); // works in JS, but should not be valid in TS
+expectError(pluck(0, {} as Obj));
+
 
 // pluck(key, record::Record)
-{
-  expectType<{ a: string, b: string }>(pluck('name', record));
-  expectType<{ readonly a: 'foo', readonly b: 'bar' }>(pluck('name', constRecord));
-  expectType<{ a: number, b: number }>(pluck('age', record));
-  expectError(pluck(1, record));
-  expectError(pluck('nope', record));
-  expectError(pluck('age', incorrectRecord));
-  // expectType<{ readonly a: undefined, readonly b: 'barrr' }>(pluck('desc', constRecord));
-  // this ^ gives false negative result, but it can't be fixed right now
-}
+expectType<{ a: string, b: string }>(pluck('name', {} as Rec));
+expectType<{ readonly a: 'foo', readonly b: 'bar' }>(pluck('name', {} as ConstRec));
+expectType<{ a: number, b: number }>(pluck('age', {} as Rec));
+expectError(pluck(1, {} as Rec));
+expectError(pluck('nope', {} as Rec));
+expectError(pluck('desc', {} as ConstRec)); // works in JS, but not valid in TS
+
 
 // pluck(__, list::Record[])(prop)
-{
-  const getFromObjList = pluck(__, [] as Obj[]);
+const getFromObjList = pluck(__, [] as Obj[]);
 
-  expectType<string[]>(getFromObjList('name'));
-  expectType<number[]>(getFromObjList('age'));
-  expectError(getFromObjList('nope'));
-}
+expectType<string[]>(getFromObjList('name'));
+expectType<number[]>(getFromObjList('age'));
+expectError(getFromObjList('nope'));
+
 
 // pluck(__, list::Array[])(prop)
-{
-  expectType<string[]>(pluck(__, [] as string[][])(0));
-  expectType<number[]>(pluck(__, [] as number[][])(1));
-  expectError(pluck(__, [] as Obj[])(0));
-}
+expectType<string[]>(pluck(__, [] as string[][])(0));
+expectType<number[]>(pluck(__, [] as number[][])(1));
+expectError(pluck(__, [] as Obj[])(0));
+
 
 // pluck(__, record::Record)(prop)
-{
-  expectType<{ a: string, b: string }>(pluck(__, record)('name'));
-  expectType<{ a: number, b: number }>(pluck(__, record)('age'));
-  expectError(pluck(__, record)('nope'));
-  expectError(pluck(__, incorrectRecord)('age'));
-}
+expectType<{ a: string, b: string }>(pluck(__, {} as Rec)('name'));
+expectType<{ a: number, b: number }>(pluck(__, {} as Rec)('age'));
+expectError(pluck(__, {} as Rec)('nope'));
+

--- a/test/pluck.test.ts
+++ b/test/pluck.test.ts
@@ -8,41 +8,103 @@ const record = {
   a: {name: 'foo', age: 13},
   b: {name: 'bar', age: 31, desc: 'barrr'}
 };
+const constRecord = {
+  a: {name: 'foo', age: 13},
+  b: {name: 'bar', age: 31, desc: 'barrr'}
+} as const;
 const incorrectRecord = {
   a: {name: 'foo', age: 13},
   b: {name: 'bar', age: 31, desc: 'barrr'},
   c: {}
 };
 
-// pluck(key, list)
-expectType<string[]>(pluck('name', [] as Obj[]));
-expectType<number[]>(pluck('age', [] as Obj[]));
-expectError(pluck('nope', [] as Obj[]));
+// pluck(key)
+{
+  const getFirstItems = pluck(0);
+  const getName = pluck('name');
+  const getAge = pluck('age');
+  const getNope = pluck('nope');
 
-// pluck(key)(list)
-expectType<string[]>(pluck('name')([] as Obj[]));
-expectType<number[]>(pluck('age')([] as Obj[]));
-expectError(pluck('nope')([] as Obj[]));
+  // pluck(key)(list::Array[])
+  {
+    expectType<string[]>(getFirstItems([] as string[][]));
+    expectType<number[]>(getFirstItems([] as number[][]));
+    expectType<1[]>(getFirstItems([] as 1[][]));
+    expectType<Obj[]>(getFirstItems([] as Obj[][]));
+    expectError(getFirstItems('string')); // works in JS, but should not be valid in TS
+    expectError(getFirstItems({} as Obj));
+  }
 
-// pluck(__, list)(prop)
-expectType<string[]>(pluck(__, [] as Obj[])('name'));
-expectType<number[]>(pluck(__, [] as Obj[])('age'));
-expectError(pluck(__, [] as Obj[])('nope'));
+  // pluck(key)(list::Record[])
+  {
+    expectType<string[]>(getName([] as Obj[]));
+    expectType<number[]>(getAge([] as Obj[]));
+    expectError(getNope([] as Obj[]));
+    expectError(getFirstItems([] as Obj[]));
+  }
 
-// pluck(key, record)
-expectType<{ a: string, b: string }>(pluck('name', record));
-expectType<{ a: number, b: number }>(pluck('age', record));
-expectError(pluck('nope', record));
-expectError(pluck('age', incorrectRecord));
+  // pluck(key)(record::Record)
+  {
+    expectType<{ a: string, b: string }>(getName(record));
+    expectType<{ a: number, b: number }>(getAge(record));
+    expectType<{ readonly a: 'foo', readonly b: 'bar' }>(getName(constRecord));
+    expectError(getNope(record));
+    expectError(getAge(incorrectRecord));
+    // expectType<{ readonly a: undefined, readonly b: 'barrr' }>(pluck('desc')(constRecord));
+    // this ^ gives false negative result, but it can't be fixed right now
+  }
+}
 
-// pluck(key)(record)
-expectType<{ a: string, b: string }>(pluck('name')(record));
-expectType<{ a: number, b: number }>(pluck('age')(record));
-expectError(pluck('nope')(record));
-expectError(pluck('age')(incorrectRecord));
+// pluck(key, list::Record[])
+{
+  expectType<string[]>(pluck('name', [] as Obj[]));
+  expectType<number[]>(pluck('age', [] as Obj[]));
+  expectError(pluck('nope', [] as Obj[]));
+  expectError(pluck(0, [] as Obj[]));
+}
 
-// pluck(__, record)(prop)
-expectType<{ a: string, b: string }>(pluck(__, record)('name'));
-expectType<{ a: number, b: number }>(pluck(__, record)('age'));
-expectError(pluck(__, record)('nope'));
-expectError(pluck(__, incorrectRecord)('age'));
+// pluck(key, list::Array[])
+{
+  expectType<string[]>(pluck(0, [] as string[][]));
+  expectType<number[]>(pluck(1, [] as number[][]));
+  expectType<1[]>(pluck(0, [] as 1[][]));
+  expectType<Obj[]>(pluck(0, [] as Obj[][]));
+  expectError(pluck(0, 'string')); // works in JS, but should not be valid in TS
+  expectError(pluck(0, {} as Obj));
+}
+
+// pluck(key, record::Record)
+{
+  expectType<{ a: string, b: string }>(pluck('name', record));
+  expectType<{ readonly a: 'foo', readonly b: 'bar' }>(pluck('name', constRecord));
+  expectType<{ a: number, b: number }>(pluck('age', record));
+  expectError(pluck(1, record));
+  expectError(pluck('nope', record));
+  expectError(pluck('age', incorrectRecord));
+  // expectType<{ readonly a: undefined, readonly b: 'barrr' }>(pluck('desc', constRecord));
+  // this ^ gives false negative result, but it can't be fixed right now
+}
+
+// pluck(__, list::Record[])(prop)
+{
+  const getFromObjList = pluck(__, [] as Obj[]);
+
+  expectType<string[]>(getFromObjList('name'));
+  expectType<number[]>(getFromObjList('age'));
+  expectError(getFromObjList('nope'));
+}
+
+// pluck(__, list::Array[])(prop)
+{
+  expectType<string[]>(pluck(__, [] as string[][])(0));
+  expectType<number[]>(pluck(__, [] as number[][])(1));
+  expectError(pluck(__, [] as Obj[])(0));
+}
+
+// pluck(__, record::Record)(prop)
+{
+  expectType<{ a: string, b: string }>(pluck(__, record)('name'));
+  expectType<{ a: number, b: number }>(pluck(__, record)('age'));
+  expectError(pluck(__, record)('nope'));
+  expectError(pluck(__, incorrectRecord)('age'));
+}

--- a/test/pluck.test.ts
+++ b/test/pluck.test.ts
@@ -4,6 +4,16 @@ import { __, pluck } from '../es';
 
 type Obj = { name: string; age: number };
 
+const record = {
+  a: {name: 'foo', age: 13},
+  b: {name: 'bar', age: 31, desc: 'barrr'}
+};
+const incorrectRecord = {
+  a: {name: 'foo', age: 13},
+  b: {name: 'bar', age: 31, desc: 'barrr'},
+  c: {}
+};
+
 // pluck(key, list)
 expectType<string[]>(pluck('name', [] as Obj[]));
 expectType<number[]>(pluck('age', [] as Obj[]));
@@ -20,16 +30,19 @@ expectType<number[]>(pluck(__, [] as Obj[])('age'));
 expectError(pluck(__, [] as Obj[])('nope'));
 
 // pluck(key, record)
-expectType<string[]>(pluck('name', {} as Record<string, Obj>));
-expectType<number[]>(pluck('age', {} as Record<string, Obj>));
-expectError(pluck('nope', {} as Record<string, Obj>));
+expectType<{ a: string, b: string }>(pluck('name', record));
+expectType<{ a: number, b: number }>(pluck('age', record));
+expectError(pluck('nope', record));
+expectError(pluck('age', incorrectRecord));
 
 // pluck(key)(record)
-expectType<string[]>(pluck('name')({} as Record<string, Obj>));
-expectType<number[]>(pluck('age')({} as Record<string, Obj>));
-expectError(pluck('nope')({} as Record<string, Obj>));
+expectType<{ a: string, b: string }>(pluck('name')(record));
+expectType<{ a: number, b: number }>(pluck('age')(record));
+expectError(pluck('nope')(record));
+expectError(pluck('age')(incorrectRecord));
 
 // pluck(__, record)(prop)
-expectType<string[]>(pluck(__, {} as Record<string, Obj>)('name'));
-expectType<number[]>(pluck(__, {} as Record<string, Obj>)('age'));
-expectError(pluck(__, {} as Record<string, Obj>)('nope'));
+expectType<{ a: string, b: string }>(pluck(__, record)('name'));
+expectType<{ a: number, b: number }>(pluck(__, record)('age'));
+expectError(pluck(__, record)('nope'));
+expectError(pluck(__, incorrectRecord)('age'));

--- a/types/pluck.d.ts
+++ b/types/pluck.d.ts
@@ -1,10 +1,10 @@
 import { Placeholder } from 'ramda';
 
 export function pluck<K extends PropertyKey>(prop: K extends Placeholder ? never : K): {
-  <U extends readonly unknown[] | Record<K, any>>(obj: Record<PropertyKey, U>): U extends readonly (infer T)[] ? T[] : U extends Record<K, infer T> ? T[] : never;
+  <U extends Record<K, any>, IK extends string>(obj: Record<IK, U>): { [KK in keyof typeof obj]: U[K] };
   <U extends readonly unknown[] | Record<K, any>>(list: U[]): U extends readonly (infer T)[] ? T[] : U extends Record<K, infer T> ? T[] : never;
 };
-export function pluck<U>(__: Placeholder, obj: Record<PropertyKey, U>): <K extends keyof U>(prop: K) => Array<U[K]>;
-export function pluck<U>(__: Placeholder, list: readonly U[]): <K extends keyof U>(prop: K) => Array<U[K]>;
-export function pluck<K extends keyof U, U>(prop: K, obj: Record<PropertyKey, U>): Array<U[K]>;
+export function pluck<K extends keyof U, U extends Record<any, any>, IK extends keyof any>(prop: K, record: Record<IK, U>): { [KK in keyof typeof record]: U[K] };
 export function pluck<K extends keyof U, U>(prop: K, list: readonly U[]): Array<U[K]>;
+export function pluck<U extends Record<any, any>, IK extends keyof any>(__: Placeholder, record: Record<IK, U>): <K extends keyof U>(prop: K) => { [KK in keyof typeof record]: U[K] };
+export function pluck<U>(__: Placeholder, list: readonly U[]): <K extends keyof U>(prop: K) => Array<U[K]>;

--- a/types/pluck.d.ts
+++ b/types/pluck.d.ts
@@ -1,10 +1,13 @@
 import { Placeholder } from 'ramda';
 
 export function pluck<K extends PropertyKey>(prop: K extends Placeholder ? never : K): {
-  <U extends Record<K, any>, IK extends string>(obj: Record<IK, U>): { [KK in keyof typeof obj]: U[K] };
-  <U extends readonly unknown[] | Record<K, any>>(list: U[]): U extends readonly (infer T)[] ? T[] : U extends Record<K, infer T> ? T[] : never;
+  <U extends O[keyof O], UK extends keyof U, O extends Record<string, any>>(obj: K extends UK ? O : never): { [OK in keyof O]: O[OK][K] };
+  <U extends readonly unknown[] | Record<K, any>>(list: readonly U[]): U extends readonly (infer T)[] ? T[] : U extends Record<K, infer T> ? T[] : never;
 };
-export function pluck<K extends keyof U, U extends Record<any, any>, IK extends keyof any>(prop: K, record: Record<IK, U>): { [KK in keyof typeof record]: U[K] };
-export function pluck<K extends keyof U, U>(prop: K, list: readonly U[]): Array<U[K]>;
-export function pluck<U extends Record<any, any>, IK extends keyof any>(__: Placeholder, record: Record<IK, U>): <K extends keyof U>(prop: K) => { [KK in keyof typeof record]: U[K] };
-export function pluck<U>(__: Placeholder, list: readonly U[]): <K extends keyof U>(prop: K) => Array<U[K]>;
+export function pluck<U>(__: Placeholder, list: readonly U[]): <K extends keyof U>(prop: U extends readonly any[] ? number : K) => U extends readonly (infer T)[] ? T[] : U extends Record<K, infer T> ? T[] : never;
+export function pluck<U extends O[keyof O], O extends Record<string, any>>(__: Placeholder, record: O): <K extends keyof U>(prop: K) => { [KK in keyof O]: O[KK][K] };
+export function pluck<
+  K extends keyof U,
+  U extends C[keyof C extends string ? keyof C : number],
+  C extends { [k: string]: Record<string, any> } | ReadonlyArray<Record<string, any> | readonly any[]>
+>(prop: K, collection: C): keyof C extends string ? { [CK in keyof C]: C[CK] extends Record<K, any> ? C[CK][K] : never } : Array<U[K]>;


### PR DESCRIPTION
The current version of pluck typing has a big mistake: it always returns an array, when it should return an object if the object is passed as a parameter.
This commit can fix this.