### PR TITLE
Update: propEq to allow wider-typing for value in comparison

### DIFF
--- a/test/allPass.test.ts
+++ b/test/allPass.test.ts
@@ -48,3 +48,21 @@ expectError(
     nickname: 'Blade'
   })
 );
+
+const isQueen = propEq('Q', 'rank');
+const isSpade = propEq('♠︎', 'suit');
+const isQueenOfSpades = allPass([isQueen, isSpade]);
+
+isQueenOfSpades({
+  rank: '2',
+  suit: '♠︎'
+});
+
+const isQueen2 = (x: Record<'rank', string>) => x.rank === 'Q';
+const isSpade2 = (x: Record<'suit', string>) => x.suit === '♠︎';
+const isQueenOfSpades2 = allPass([isQueen2, isSpade2]);
+
+isQueenOfSpades2({
+  rank: '2',
+  suit: '♠︎'
+});

--- a/test/anyPass.test.ts
+++ b/test/anyPass.test.ts
@@ -25,13 +25,33 @@ expectType<boolean>(
   })
 );
 
+expectType<boolean>(
+  isVampire({
+    age: 300, // any number
+    garlic_allergy: false, // any bool
+    sun_allergy: false, // any bool
+    fast: null
+    // fear: undefined // can leave out because `undefined` are considered optional
+  })
+);
+
 expectError(
   isVampire({
     age: 21,
     garlic_allergy: true,
     sun_allergy: true,
-    fast: false,
-    fear: true
+    fast: false,  // wrong type
+    fear: undefined
+  })
+);
+
+expectError(
+  isVampire({
+    age: 21,
+    garlic_allergy: true,
+    sun_allergy: true,
+    fast: null,
+    fear: true  // wrong type
   })
 );
 
@@ -39,7 +59,9 @@ expectError(
   isVampire({
     age: 40,
     garlic_allergy: true,
-    fear: false
+    // sun_allergy: true, // can't have missing prop
+    fast: null,
+    fear: undefined
   })
 );
 
@@ -48,3 +70,4 @@ expectError(
     nickname: 'Blade'
   })
 );
+

--- a/test/anyPass.test.ts
+++ b/test/anyPass.test.ts
@@ -27,31 +27,11 @@ expectType<boolean>(
 
 expectType<boolean>(
   isVampire({
-    age: 300, // any number
-    garlic_allergy: false, // any bool
-    sun_allergy: false, // any bool
-    fast: null
-    // fear: undefined // can leave out because `undefined` are considered optional
-  })
-);
-
-expectError(
-  isVampire({
-    age: 21,
-    garlic_allergy: true,
-    sun_allergy: true,
-    fast: false,  // wrong type
-    fear: undefined
-  })
-);
-
-expectError(
-  isVampire({
     age: 21,
     garlic_allergy: true,
     sun_allergy: true,
     fast: null,
-    fear: true  // wrong type
+    fear: undefined
   })
 );
 
@@ -59,9 +39,7 @@ expectError(
   isVampire({
     age: 40,
     garlic_allergy: true,
-    // sun_allergy: true, // can't have missing prop
-    fast: null,
-    fear: undefined
+    fear: false
   })
 );
 
@@ -71,3 +49,25 @@ expectError(
   })
 );
 
+const isQueen = propEq('Q', 'rank');
+const isSpade = propEq('♠︎', 'suit');
+const isQueenOfSpades = anyPass([isQueen, isSpade]);
+
+expectType<boolean>(isQueenOfSpades({
+  rank: '2',
+  suit: '♠︎'
+}));
+
+expectError(isQueenOfSpades({
+  rank: 2,
+  suit: '♠︎'
+}));
+
+const isQueen2 = (x: Record<'rank', string>) => x.rank === 'Q';
+const isSpade2 = (x: Record<'suit', string>) => x.suit === '♠︎';
+const isQueenOfSpades2 = anyPass([isQueen2, isSpade2]);
+
+isQueenOfSpades2({
+  rank: '2',
+  suit: '♠︎'
+});

--- a/test/propEq.test.ts
+++ b/test/propEq.test.ts
@@ -13,10 +13,12 @@ type Obj = {
 // explanation
 // `obj.union` is type `'A' | 'B'` and `val` is `string`
 // typescript allows comparison because as long as one side extends the other, it's ok
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function doesEq(val: string, obj: Obj) {
   return obj.union === val;
 }
 // this is different from assignment that errors because`string` is too wide for `'A' | 'B'`
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function assign(val: string, obj: Obj) {
   // @ts-expect-error -- remove this to see the error (need this so `npm run test` pasts)
   obj.union = val;
@@ -30,20 +32,44 @@ expectType<boolean>(propEq('foo', 'union', {} as Obj));
 expectType<boolean>(propEq('else', 'union', {} as Obj));
 // completely different type fails
 expectError(propEq(2, 'union', {} as Obj));
+// other props work as expected
+expectType<boolean>(propEq(2, 'num', {} as Obj));
+expectError(propEq(2, 'u', {} as Obj));
+expectType<boolean>(propEq(2, 'num', {} as Obj));
+expectError(propEq(2, 'n', {} as Obj));
+expectType<boolean>(propEq(null, 'n', {} as Obj));
+expectError(propEq(2, 'n', {} as Obj));
+expectType<boolean>(propEq(undefined, 'u', {} as Obj));
 
 // propEq(val)(name)(obj)
 expectType<boolean>(propEq('foo')('union')({} as Obj));
 // any string works here, see the above explanation as to why
 expectType<boolean>(propEq('else')('union')({} as Obj));
 // completely different type fails
-expectError(propEq(2)('union')({} as Obj));
+expectError(propEq(2, 'union', {} as Obj));
+// other props work as expected
+expectType<boolean>(propEq(2, 'num', {} as Obj));
+expectError(propEq(2)('u')({} as Obj));
+expectType<boolean>(propEq(2)('num')({} as Obj));
+expectError(propEq(2)('n')({} as Obj));
+expectType<boolean>(propEq(null, 'n', {} as Obj));
+expectError(propEq(2)('n')({} as Obj));
+expectType<boolean>(propEq(undefined, 'u', {} as Obj));
 
-// propEq(val)(name), obj)
+// propEq(val)(name, obj)
 expectType<boolean>(propEq('foo')('union', {} as Obj));
 // 'nope' is inferred as 'string' here.
 expectType<boolean>(propEq('nope')('union', {} as Obj));
 // completely different type fails
 expectError(propEq(2)('union', {} as Obj));
+// other props work as expected
+expectType<boolean>(propEq(2)('num', {} as Obj));
+expectError(propEq(2)('u', {} as Obj));
+expectType<boolean>(propEq(2)('num', {} as Obj));
+expectError(propEq(2)('n', {} as Obj));
+expectType<boolean>(propEq(null)('n', {} as Obj));
+expectError(propEq(2)('n', {} as Obj));
+expectType<boolean>(propEq(undefined, 'u', {} as Obj));
 
 // propEq(val, name)(obj)
 expectType<boolean>(propEq('foo', 'union')({} as Obj));
@@ -51,3 +77,11 @@ expectType<boolean>(propEq('foo', 'union')({} as Obj));
 expectType<boolean>(propEq('else', 'union')({} as Obj));
 // completely different type fails
 expectError(propEq(2, 'union')({} as Obj));
+// other props work as expected
+expectType<boolean>(propEq(2, 'num')({} as Obj));
+expectError(propEq(2, 'u')({} as Obj));
+expectType<boolean>(propEq(2, 'num')({} as Obj));
+expectError(propEq(2, 'n')({} as Obj));
+expectType<boolean>(propEq(null, 'n')({} as Obj));
+expectError(propEq(2, 'n')({} as Obj));
+expectType<boolean>(propEq(undefined, 'u')({} as Obj));

--- a/test/propEq.test.ts
+++ b/test/propEq.test.ts
@@ -4,85 +4,162 @@ import { propEq } from '../es';
 
 type Obj = {
   literals: 'A' | 'B';
-  union: number | string;
-  nullable: number | null;
+  unions: number | string;
+  nullable: number | null | undefined;
   optional?: number;
 };
 
 const obj = {} as Obj;
 
-// propEq(val)(name)(obj)
+const literalVar = 'A';
+let typedVar: 'A' | 'B' = 'A';
+
+//
+// literals
+//
+
+// happy path works as expected
 expectType<boolean>(propEq('A')('literals')(obj));
-// any string works here and will return boolean, we can live with that
-expectType<boolean>(propEq('C')('literals')(obj));
-// a different base type returns `never`
-expectType<never>(propEq(2)('literals')(obj));
-// unions work
-expectType<boolean>(propEq(2)('union')(obj));
-expectType<boolean>(propEq('2')('union')(obj));
-expectType<never>(propEq(true)('union')(obj));
-// nullable works
-expectType<boolean>(propEq(2)('nullable')(obj));
-expectType<boolean>(propEq(null)('nullable')(obj));
-// optionals work
-expectType<boolean>(propEq(2)('optional')(obj));
-expectType<boolean>(propEq(undefined)('optional')(obj));
-// unknownKey errors
-expectError(propEq('whatever')('unknownKey')(obj));
-
-// propEq(val)(name, obj)
-expectType<boolean>(propEq('A')('literals', obj));
-// any string works here and will return boolean, we can live with that
-expectType<boolean>(propEq('C')('literals', obj));
-// a different base type returns `never`
-expectType<never>(propEq(2)('literals', obj));
-// unions work
-expectType<boolean>(propEq(2)('union', obj));
-expectType<boolean>(propEq('2')('union', obj));
-expectType<never>(propEq(true)('union', obj));
-// nullable works
-expectType<boolean>(propEq(2)('nullable', obj));
-expectType<boolean>(propEq(null)('nullable', obj));
-// optionals work
-expectType<boolean>(propEq(2)('optional', obj));
-expectType<boolean>(propEq(undefined)('optional', obj));
-// unknownKey errors
-expectError(propEq('whatever')('unknownKey', obj));
-
-// propEq(val, name)(obj)
 expectType<boolean>(propEq('A', 'literals')(obj));
-// any string works here and will return boolean, we can live with that
-expectType<boolean>(propEq('C', 'literals')(obj));
-// a different base type returns `never`
-expectType<never>(propEq(2, 'literals')(obj));
-// unions work
-expectType<boolean>(propEq(2, 'union')(obj));
-expectType<boolean>(propEq('2', 'union')(obj));
-expectType<never>(propEq(true, 'union')(obj));
-// nullable works
-expectType<boolean>(propEq(2, 'nullable')(obj));
-expectType<boolean>(propEq(null, 'nullable')(obj));
-// optionals work
-expectType<boolean>(propEq(2, 'optional')(obj));
-expectType<boolean>(propEq(undefined, 'optional')(obj));
-// unknownKey errors
-expectError(propEq('whatever', 'unknownKey')(obj));
-
-// propEq(val, name, obj)
 expectType<boolean>(propEq('A', 'literals', obj));
-// any string works here and will return boolean, we can live with that
+
+// rejects if typeof val not U[K]
+expectError(propEq('C')('literals')(obj));
+expectError(propEq('C', 'literals')(obj));
 expectError(propEq('C', 'literals', obj));
-// a different base type returns `never`
+
+expectError(propEq(2)('literals')(obj));
+expectError(propEq(2, 'literals')(obj));
 expectError(propEq(2, 'literals', obj));
-// unions work
-expectType<boolean>(propEq(2, 'union', obj));
-expectType<boolean>(propEq('2', 'union', obj));
-expectError(propEq(true, 'union', obj));
-// nullable works
-expectType<boolean>(propEq(2, 'nullable', obj));
+
+// works for variable literal of correct type
+expectType<boolean>(propEq(literalVar)('literals')(obj));
+expectType<boolean>(propEq(literalVar, 'literals')(obj));
+expectType<boolean>(propEq(literalVar, 'literals', obj));
+
+// works for variable typed to be same
+expectType<boolean>(propEq(typedVar)('literals')(obj));
+expectType<boolean>(propEq(typedVar, 'literals')(obj));
+expectType<boolean>(propEq(typedVar, 'literals', obj));
+
+// rejects if typeof val is too wide
+expectError(propEq('A' as string)('literals')(obj));
+expectError(propEq('A' as string, 'literals')(obj));
+expectError(propEq('A' as string, 'literals', obj));
+
+// rejects if key is not on obj
+expectError(propEq('A')('literals')({} as Omit<Obj, 'literals'>));
+expectError(propEq('A', 'literals')({} as Omit<Obj, 'literals'>));
+expectError(propEq('A', 'literals', {} as Omit<Obj, 'literals'>));
+
+// rejects empty object literal
+expectError(propEq('A')('literals')({}));
+expectError(propEq('A', 'literals')({}));
+expectError(propEq('A', 'literals', {}));
+
+//
+// unions
+//
+
+// happy path works as expected
+expectType<boolean>(propEq('1')('unions')(obj));
+expectType<boolean>(propEq('1', 'unions')(obj));
+expectType<boolean>(propEq('1', 'unions', obj));
+
+expectType<boolean>(propEq(1)('unions')(obj));
+expectType<boolean>(propEq(1, 'unions')(obj));
+expectType<boolean>(propEq(1, 'unions', obj));
+
+// rejects if typeof val not part of union type
+expectError(propEq(true)('unions')(obj));
+expectError(propEq(true, 'unions')(obj));
+expectError(propEq(true, 'unions', obj));
+
+// rejects if key is not on obj
+expectError(propEq('1')('unions')({} as Omit<Obj, 'unions'>));
+expectError(propEq('1', 'unions')({} as Omit<Obj, 'unions'>));
+expectError(propEq('1', 'unions', {} as Omit<Obj, 'unions'>));
+
+// rejects empty object literal
+expectError(propEq('1')('unions')({}));
+expectError(propEq('1', 'unions')({}));
+expectError(propEq('1', 'unions', {}));
+
+//
+// nullable
+//
+
+// happy path works as expected
+expectType<boolean>(propEq(1)('nullable')(obj));
+expectType<boolean>(propEq(1, 'nullable')(obj));
+expectType<boolean>(propEq(1, 'nullable', obj));
+
+expectType<boolean>(propEq(null)('nullable')(obj));
+expectType<boolean>(propEq(null, 'nullable')(obj));
 expectType<boolean>(propEq(null, 'nullable', obj));
-// optionals work
-expectType<boolean>(propEq(2, 'optional', obj));
+
+expectType<boolean>(propEq(undefined)('nullable')(obj));
+expectType<boolean>(propEq(undefined, 'nullable')(obj));
+expectType<boolean>(propEq(undefined, 'nullable', obj));
+
+// rejects if typeof val not part of union type
+expectError(propEq(true)('nullable')(obj));
+expectError(propEq(true, 'nullable')(obj));
+expectError(propEq(true, 'nullable', obj));
+
+// rejects if key is not on obj
+expectError(propEq(1)('nullable')({} as Omit<Obj, 'nullable'>));
+expectError(propEq(1, 'nullable')({} as Omit<Obj, 'nullable'>));
+expectError(propEq(1, 'nullable', {} as Omit<Obj, 'nullable'>));
+
+// rejects empty object literal
+expectError(propEq(1)('nullable')({}));
+expectError(propEq(1, 'nullable')({}));
+expectError(propEq(1, 'nullable', {}));
+
+//
+// optional
+//
+
+// happy path works as expected
+expectType<boolean>(propEq(1)('optional')(obj));
+expectType<boolean>(propEq(1, 'optional')(obj));
+expectType<boolean>(propEq(1, 'optional', obj));
+
+expectType<boolean>(propEq(undefined)('optional')(obj));
+expectType<boolean>(propEq(undefined, 'optional')(obj));
 expectType<boolean>(propEq(undefined, 'optional', obj));
-// unknownKey errors
-expectError(propEq('whatever', 'unknownKey', obj));
+
+// `null` produces error for `optional`. this is expected because typescript strictNullCheck `null !== undefined`
+expectError(propEq(null)('optional')(obj));
+expectError(propEq(null, 'optional')(obj));
+expectError(propEq(null, 'optional', obj));
+
+// rejects if typeof val not part of union type
+expectError(propEq(true)('optional')(obj));
+expectError(propEq(true, 'optional')(obj));
+expectError(propEq(true, 'optional', obj));
+
+// rejects if key is not on obj
+expectError(propEq(1)('optional')({} as Omit<Obj, 'optional'>));
+expectError(propEq(1, 'optional')({} as Omit<Obj, 'optional'>));
+expectError(propEq(1, 'optional', {} as Omit<Obj, 'optional'>));
+
+// rejects empty object literal literal
+expectError(propEq(1)('optional')({}));
+expectError(propEq(1, 'optional')({}));
+expectError(propEq(1, 'optional', {}));
+
+//
+// other non-happy paths
+//
+
+// rejects unknown key
+expectError(propEq(1)('whatever')(obj));
+expectError(propEq(1, 'whatever')(obj));
+expectError(propEq(1, 'whatever', obj));
+
+// rejects unknown key on emptyu object literal
+expectError(propEq(1)('whatever')({}));
+expectError(propEq(1, 'whatever')({}));
+expectError(propEq(1, 'whatever', {}));

--- a/test/propEq.test.ts
+++ b/test/propEq.test.ts
@@ -3,85 +3,86 @@ import { expectError, expectType } from 'tsd';
 import { propEq } from '../es';
 
 type Obj = {
-  union: 'foo' | 'bar';
-  str: string;
-  num: number;
-  u: undefined;
-  n: null;
+  literals: 'A' | 'B';
+  union: number | string;
+  nullable: number | null;
+  optional?: number;
 };
 
-const str: string = '';
-// explanation
-
-// `string` is too wide for `'foo' | 'bar` for assignment
-({} as Obj).union = str;
-// but for comparison is fine
-({} as Obj).union === str;
-// null and undefined are allowed as well
-({} as Obj).str === null;
-({} as Obj).str === undefined;
-
-// this is why we use `WidenLiterals` in the type definition
-
-// propEq(val, name, obj)
-expectType<boolean>(propEq('foo', 'union', {} as Obj));
-// any string works here, see the above explanation as to why
-expectType<boolean>(propEq('else', 'union', {} as Obj));
-// also null or undefined
-expectType<boolean>(propEq(null, 'union', {} as Obj));
-expectType<boolean>(propEq(undefined, 'union', {} as Obj));
-// completely different type fails
-expectError(propEq(2, 'union', {} as Obj));
-// other props work as expected
-expectType<boolean>(propEq(2, 'num', {} as Obj));
-expectError(propEq(2, 'u', {} as Obj));
-expectType<boolean>(propEq(2, 'num', {} as Obj));
-expectError(propEq(2, 'n', {} as Obj));
-expectType<boolean>(propEq(null, 'n', {} as Obj));
-expectError(propEq(2, 'n', {} as Obj));
-expectType<boolean>(propEq(undefined, 'u', {} as Obj));
+const obj = {} as Obj;
 
 // propEq(val)(name)(obj)
-expectType<boolean>(propEq('foo')('union')({} as Obj));
-// any string works here, see the above explanation as to why
-expectType<boolean>(propEq('else')('union')({} as Obj));
-// completely different type fails
-expectError(propEq(2, 'union', {} as Obj));
-// other props work as expected
-expectType<boolean>(propEq(2, 'num', {} as Obj));
-expectError(propEq(2)('u')({} as Obj));
-expectType<boolean>(propEq(2)('num')({} as Obj));
-expectError(propEq(2)('n')({} as Obj));
-expectType<boolean>(propEq(null, 'n', {} as Obj));
-expectError(propEq(2)('n')({} as Obj));
-expectType<boolean>(propEq(undefined, 'u', {} as Obj));
+expectType<boolean>(propEq('A')('literals')(obj));
+// any string works here and will return boolean, we can live with that
+expectType<boolean>(propEq('C')('literals')(obj));
+// a different base type returns `never`
+expectType<never>(propEq(2)('literals')(obj));
+// unions work
+expectType<boolean>(propEq(2)('union')(obj));
+expectType<boolean>(propEq('2')('union')(obj));
+expectType<never>(propEq(true)('union')(obj));
+// nullable works
+expectType<boolean>(propEq(2)('nullable')(obj));
+expectType<boolean>(propEq(null)('nullable')(obj));
+// optionals work
+expectType<boolean>(propEq(2)('optional')(obj));
+expectType<boolean>(propEq(undefined)('optional')(obj));
+// unknownKey errors
+expectError(propEq('whatever')('unknownKey')(obj));
 
 // propEq(val)(name, obj)
-expectType<boolean>(propEq('foo')('union', {} as Obj));
-// 'nope' is inferred as 'string' here.
-expectType<boolean>(propEq('nope')('union', {} as Obj));
-// completely different type fails
-expectError(propEq(2)('union', {} as Obj));
-// other props work as expected
-expectType<boolean>(propEq(2)('num', {} as Obj));
-expectError(propEq(2)('u', {} as Obj));
-expectType<boolean>(propEq(2)('num', {} as Obj));
-expectError(propEq(2)('n', {} as Obj));
-expectType<boolean>(propEq(null)('n', {} as Obj));
-expectError(propEq(2)('n', {} as Obj));
-expectType<boolean>(propEq(undefined, 'u', {} as Obj));
+expectType<boolean>(propEq('A')('literals', obj));
+// any string works here and will return boolean, we can live with that
+expectType<boolean>(propEq('C')('literals', obj));
+// a different base type returns `never`
+expectType<never>(propEq(2)('literals', obj));
+// unions work
+expectType<boolean>(propEq(2)('union', obj));
+expectType<boolean>(propEq('2')('union', obj));
+expectType<never>(propEq(true)('union', obj));
+// nullable works
+expectType<boolean>(propEq(2)('nullable', obj));
+expectType<boolean>(propEq(null)('nullable', obj));
+// optionals work
+expectType<boolean>(propEq(2)('optional', obj));
+expectType<boolean>(propEq(undefined)('optional', obj));
+// unknownKey errors
+expectError(propEq('whatever')('unknownKey', obj));
 
 // propEq(val, name)(obj)
-expectType<boolean>(propEq('foo', 'union')({} as Obj));
-// any string works here, see the above explanation as to why
-expectType<boolean>(propEq('else', 'union')({} as Obj));
-// completely different type fails
-expectError(propEq(2, 'union')({} as Obj));
-// other props work as expected
-expectType<boolean>(propEq(2, 'num')({} as Obj));
-expectError(propEq(2, 'u')({} as Obj));
-expectType<boolean>(propEq(2, 'num')({} as Obj));
-expectError(propEq(2, 'n')({} as Obj));
-expectType<boolean>(propEq(null, 'n')({} as Obj));
-expectError(propEq(2, 'n')({} as Obj));
-expectType<boolean>(propEq(undefined, 'u')({} as Obj));
+expectType<boolean>(propEq('A', 'literals')(obj));
+// any string works here and will return boolean, we can live with that
+expectType<boolean>(propEq('C', 'literals')(obj));
+// a different base type returns `never`
+expectType<never>(propEq(2, 'literals')(obj));
+// unions work
+expectType<boolean>(propEq(2, 'union')(obj));
+expectType<boolean>(propEq('2', 'union')(obj));
+expectType<never>(propEq(true, 'union')(obj));
+// nullable works
+expectType<boolean>(propEq(2, 'nullable')(obj));
+expectType<boolean>(propEq(null, 'nullable')(obj));
+// optionals work
+expectType<boolean>(propEq(2, 'optional')(obj));
+expectType<boolean>(propEq(undefined, 'optional')(obj));
+// unknownKey errors
+expectError(propEq('whatever', 'unknownKey')(obj));
+
+// propEq(val, name, obj)
+expectType<boolean>(propEq('A', 'literals', obj));
+// any string works here and will return boolean, we can live with that
+expectError(propEq('C', 'literals', obj));
+// a different base type returns `never`
+expectError(propEq(2, 'literals', obj));
+// unions work
+expectType<boolean>(propEq(2, 'union', obj));
+expectType<boolean>(propEq('2', 'union', obj));
+expectError(propEq(true, 'union', obj));
+// nullable works
+expectType<boolean>(propEq(2, 'nullable', obj));
+expectType<boolean>(propEq(null, 'nullable', obj));
+// optionals work
+expectType<boolean>(propEq(2, 'optional', obj));
+expectType<boolean>(propEq(undefined, 'optional', obj));
+// unknownKey errors
+expectError(propEq('whatever', 'unknownKey', obj));

--- a/test/propEq.test.ts
+++ b/test/propEq.test.ts
@@ -10,17 +10,31 @@ type Obj = {
   n: null;
 };
 
+// explanation
+// `obj.union` is type `'A' | 'B'` and `val` is `string`
+// typescript allows comparison because as long as one side extends the other, it's ok
+function doesEq(val: string, obj: Obj) {
+  return obj.union === val;
+}
+// this is different from assignment that errors because`string` is too wide for `'A' | 'B'`
+function assign(val: string, obj: Obj) {
+  // @ts-expect-error -- remove this to see the error (need this so `npm run test` pasts)
+  obj.union = val;
+}
+
+// this is why we use `WidenLiterals` in the type definition
+
 // propEq(val, name, obj)
 expectType<boolean>(propEq('foo', 'union', {} as Obj));
-// non-union string fails
-expectError(propEq('nope', 'union', {} as Obj));
+// any string works here, see the above explanation as to why
+expectType<boolean>(propEq('else', 'union', {} as Obj));
 // completely different type fails
 expectError(propEq(2, 'union', {} as Obj));
 
 // propEq(val)(name)(obj)
 expectType<boolean>(propEq('foo')('union')({} as Obj));
-// 'nope' is inferred as 'string' here.
-expectType<boolean>(propEq('nope')('union')({} as Obj));
+// any string works here, see the above explanation as to why
+expectType<boolean>(propEq('else')('union')({} as Obj));
 // completely different type fails
 expectError(propEq(2)('union')({} as Obj));
 
@@ -33,7 +47,7 @@ expectError(propEq(2)('union', {} as Obj));
 
 // propEq(val, name)(obj)
 expectType<boolean>(propEq('foo', 'union')({} as Obj));
-// 'nope' is inferred as 'string' here.
-expectType<boolean>(propEq('nope', 'union')({} as Obj));
+// any string works here, see the above explanation as to why
+expectType<boolean>(propEq('else', 'union')({} as Obj));
 // completely different type fails
 expectError(propEq(2, 'union')({} as Obj));

--- a/test/propEq.test.ts
+++ b/test/propEq.test.ts
@@ -10,19 +10,16 @@ type Obj = {
   n: null;
 };
 
+const str: string = '';
 // explanation
-// `obj.union` is type `'A' | 'B'` and `val` is `string`
-// typescript allows comparison because as long as one side extends the other, it's ok
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function doesEq(val: string, obj: Obj) {
-  return obj.union === val;
-}
-// this is different from assignment that errors because`string` is too wide for `'A' | 'B'`
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function assign(val: string, obj: Obj) {
-  // @ts-expect-error -- remove this to see the error (need this so `npm run test` pasts)
-  obj.union = val;
-}
+
+// `string` is too wide for `'foo' | 'bar` for assignment
+({} as Obj).union = str;
+// but for comparison is fine
+({} as Obj).union === str;
+// null and undefined are allowed as well
+({} as Obj).str === null;
+({} as Obj).str === undefined;
 
 // this is why we use `WidenLiterals` in the type definition
 
@@ -30,6 +27,9 @@ function assign(val: string, obj: Obj) {
 expectType<boolean>(propEq('foo', 'union', {} as Obj));
 // any string works here, see the above explanation as to why
 expectType<boolean>(propEq('else', 'union', {} as Obj));
+// also null or undefined
+expectType<boolean>(propEq(null, 'union', {} as Obj));
+expectType<boolean>(propEq(undefined, 'union', {} as Obj));
 // completely different type fails
 expectError(propEq(2, 'union', {} as Obj));
 // other props work as expected

--- a/test/propEq.test.ts
+++ b/test/propEq.test.ts
@@ -11,9 +11,6 @@ type Obj = {
 
 const obj = {} as Obj;
 
-const literalVar = 'A';
-let typedVar: 'A' | 'B' = 'A';
-
 //
 // literals
 //

--- a/test/propEq.test.ts
+++ b/test/propEq.test.ts
@@ -23,28 +23,21 @@ expectType<boolean>(propEq('A')('literals')(obj));
 expectType<boolean>(propEq('A', 'literals')(obj));
 expectType<boolean>(propEq('A', 'literals', obj));
 
-// rejects if typeof val not U[K]
-expectError(propEq('C')('literals')(obj));
-expectError(propEq('C', 'literals')(obj));
+// accepts any type that obj[key] can be widened too
+expectType<boolean>(propEq('C')('literals')(obj));
+expectType<boolean>(propEq('C', 'literals')(obj));
+// only propEq(val, key, obj) requests non-widened types
 expectError(propEq('C', 'literals', obj));
 
+// rejects if type cannot be widened too
 expectError(propEq(2)('literals')(obj));
 expectError(propEq(2, 'literals')(obj));
 expectError(propEq(2, 'literals', obj));
 
-// works for variable literal of correct type
-expectType<boolean>(propEq(literalVar)('literals')(obj));
-expectType<boolean>(propEq(literalVar, 'literals')(obj));
-expectType<boolean>(propEq(literalVar, 'literals', obj));
-
-// works for variable typed to be same
-expectType<boolean>(propEq(typedVar)('literals')(obj));
-expectType<boolean>(propEq(typedVar, 'literals')(obj));
-expectType<boolean>(propEq(typedVar, 'literals', obj));
-
-// rejects if typeof val is too wide
-expectError(propEq('A' as string)('literals')(obj));
-expectError(propEq('A' as string, 'literals')(obj));
+// manually widened also works
+expectType<boolean>(propEq('A' as string)('literals')(obj));
+expectType<boolean>(propEq('A' as string, 'literals')(obj));
+// only rejects for propEq(val, key, obj), `string` is too wide for 'A' | 'B'
 expectError(propEq('A' as string, 'literals', obj));
 
 // rejects if key is not on obj

--- a/types/allPass.d.ts
+++ b/types/allPass.d.ts
@@ -1,11 +1,24 @@
+// narrowing
 export function allPass<T, TF1 extends T, TF2 extends T>(
-  predicates: [(a: T) => a is TF1, (a: T) => a is TF2]
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2
+  ]
 ): (a: T) => a is TF1 & TF2;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2,
+    (a: T) => a is TF3
+  ],
 ): (a: T) => a is TF1 & TF2 & TF3;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T>(
-  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3, (a: T) => a is TF4],
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2,
+    (a: T) => a is TF3,
+    (a: T) => a is TF4
+  ],
 ): (a: T) => a is TF1 & TF2 & TF3 & TF4;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T>(
   predicates: [
@@ -26,4 +39,46 @@ export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 exte
     (a: T) => a is TF6
   ],
 ): (a: T) => a is TF1 & TF2 & TF3 & TF4 & TF5 & TF6;
+// regular
+export function allPass<T1, T2>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean
+  ],
+): (a: T1 & T2) => boolean;
+export function allPass<T1, T2, T3>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean,
+    (a: T3) => boolean
+  ],
+): (a: T1 & T2 & T3) => boolean;
+export function allPass<T1, T2, T3, T4>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean,
+    (a: T3) => boolean,
+    (a: T4) => boolean
+  ],
+): (a: T1 & T2 & T3 & T4) => boolean;
+export function allPass<T1, T2, T3, T4, T5>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean,
+    (a: T3) => boolean,
+    (a: T4) => boolean,
+    (a: T5) => boolean
+  ],
+): (a: T1 & T2 & T3 & T4 & T5) => boolean;
+export function allPass<T1, T2, T3, T4, T5, T6>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean,
+    (a: T3) => boolean,
+    (a: T4) => boolean,
+    (a: T5) => boolean,
+    (a: T6) => boolean
+  ],
+): (a: T1 & T2 & T3 & T4 & T5 & T6) => boolean;
+// catch-all
 export function allPass<F extends (...args: any[]) => boolean>(predicates: readonly F[]): F;

--- a/types/anyPass.d.ts
+++ b/types/anyPass.d.ts
@@ -1,14 +1,24 @@
+// narrowing
 export function anyPass<T, TF1 extends T, TF2 extends T>(
-  predicates: [(a: T) => a is TF1, (a: T) => a is TF2],
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2
+  ],
 ): (a: T) => a is TF1 | TF2;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
-): (a: T) => a is TF1 | TF2 | TF3;
-export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2,
+    (a: T) => a is TF3
+  ],
 ): (a: T) => a is TF1 | TF2 | TF3;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T>(
-  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3, (a: T) => a is TF4],
+  predicates: [
+    (a: T) => a is TF1,
+    (a: T) => a is TF2,
+    (a: T) => a is TF3,
+    (a: T) => a is TF4
+  ],
 ): (a: T) => a is TF1 | TF2 | TF3 | TF4;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T>(
   predicates: [
@@ -29,4 +39,46 @@ export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 exte
     (a: T) => a is TF6
   ],
 ): (a: T) => a is TF1 | TF2 | TF3 | TF4 | TF5 | TF6;
+// regular
+export function anyPass<T1, T2>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean
+  ],
+): (a: T1 & T2) => boolean;
+export function anyPass<T1, T2, T3>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean,
+    (a: T3) => boolean
+  ],
+): (a: T1 & T2 & T3) => boolean;
+export function anyPass<T1, T2, T3, T4>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean,
+    (a: T3) => boolean,
+    (a: T4) => boolean
+  ],
+): (a: T1 & T2 & T3 & T4) => boolean;
+export function anyPass<T1, T2, T3, T4, T5>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean,
+    (a: T3) => boolean,
+    (a: T4) => boolean,
+    (a: T5) => boolean
+  ],
+): (a: T1 & T2 & T3 & T4 & T5) => boolean;
+export function anyPass<T1, T2, T3, T4, T5, T6>(
+  predicates: [
+    (a: T1) => boolean,
+    (a: T2) => boolean,
+    (a: T3) => boolean,
+    (a: T4) => boolean,
+    (a: T5) => boolean,
+    (a: T6) => boolean
+  ],
+): (a: T1 & T2 & T3 & T4 & T5 & T6) => boolean;
+// catch-all
 export function anyPass<F extends (...args: any[]) => boolean>(predicates: readonly F[]): F;

--- a/types/propEq.d.ts
+++ b/types/propEq.d.ts
@@ -1,40 +1,14 @@
-import { Placeholder, WidenLiterals } from './util/tools';
+import { WidenLiterals } from './util/tools';
 
 // propEq(val)
 export function propEq<T>(val: T): {
   // propEq(val)(name)(obj)
-  <K extends PropertyKey>(name: K): (obj: Record<K, WidenLiterals<T>>) => boolean;
-  // propEq(val)(__, obj)(name)
-  <U>(__: Placeholder, obj: U): <K extends keyof U>(name: K) => U[K] extends WidenLiterals<T> ? boolean : never;
+  <K extends PropertyKey>(name: K): <U extends Partial<Record<K, any>>>(obj: U) => T extends WidenLiterals<U[K]> ? boolean : never;
   // propEq(val)(name, obj)
-  <K extends PropertyKey>(name: K, obj: Record<K, WidenLiterals<T>>): boolean;
-};
-
-// propEq(__, name)
-export function propEq<K extends PropertyKey>(__: Placeholder, name: K): {
-  // propEq(val)(obj)
-  <T>(val: T): (obj: Record<K, WidenLiterals<T>>) => boolean;
-  // propEq(__, obj)(val)
-  <U extends Record<K, any>>(__: Placeholder, obj: U): (val: WidenLiterals<U[K]>) => boolean;
-  // propEq(val, obj)
-  <T>(val: T, obj: Record<K, WidenLiterals<T>>): boolean;
+  // type it this way for better error message for unknown keys
+  <K extends keyof U, U extends Partial<Record<PropertyKey, any>>>(name: K, obj: U): T extends WidenLiterals<U[K]> ? boolean : never;
 };
 // propEq(val, name)(obj)
-export function propEq<T, K extends PropertyKey>(val: T, name: K): (obj: Record<K, WidenLiterals<T>>) => boolean;
-
-// propEq(__, __, obj)
-export function propEq<U>(__: Placeholder, __2: Placeholder, obj: U): {
-  // propEq(__, __, obj)(val)(name)
-  <T>(val: T): <K extends keyof U>(name: K) => boolean;
-  // propEq(__, __, obj)(__, key)(name)
-  <K extends keyof U>(__: Placeholder, key: K): (val: WidenLiterals<U[K]>) => boolean;
-  // propEq(__, __, obj)(name, key)
-  <K extends keyof U>(val: WidenLiterals<U[K]>, name: K): boolean;
-};
-
-// propEq(__, name, obj)(val)
-export function propEq<K extends keyof U, U>(__: Placeholder, name: K, obj: U): (val: WidenLiterals<U[K]>) => boolean;
-// propEq(val, __, obj)(name)
-export function propEq<T, U>(val: T, __: Placeholder, obj: U): <K extends keyof U>(name: K) => U[K] extends WidenLiterals<T> ? boolean : never;
+export function propEq<T, K extends PropertyKey>(val: T, name: K): <U extends Partial<Record<PropertyKey, any>>>(obj: U) => T extends WidenLiterals<U[K]> ? boolean : never;
 // propEq(val, name, obj)
-export function propEq<K extends keyof U, U>(val: WidenLiterals<U[K]>, name: K, obj: U): boolean;
+export function propEq<K extends keyof U, U>(val: U[K], name: K, obj: U): boolean;

--- a/types/propEq.d.ts
+++ b/types/propEq.d.ts
@@ -3,11 +3,11 @@ import { WidenLiterals } from './util/tools';
 // propEq(val)
 export function propEq<T>(val: T): {
   // propEq(val)(name)(obj)
-  <K extends PropertyKey>(name: K): <U extends Record<K, any>>(obj: T extends WidenLiterals<U[K]> ? U : never) => boolean;
+  <K extends PropertyKey>(name: K): <U extends Partial<Record<K, any>>>(obj: Required<U> extends Record<K, any> ? T extends WidenLiterals<U[K]> ? U : never : never) => boolean;
   // propEq(val)(name, obj)
-  <K extends keyof U, U extends Record<PropertyKey, any>>(name: K, obj: T extends WidenLiterals<U[K]> ? U : never): boolean;
+  <K extends PropertyKey, U extends Partial<Record<K, any>>>(name: K, obj: Required<U> extends Record<K, any> ? T extends WidenLiterals<U[K]> ? U : never : never): boolean;
 };
 // propEq(val, name)(obj)
-export function propEq<T, K extends PropertyKey>(val: T, name: K): <U extends Record<K, any>>(obj: T extends WidenLiterals<U[K]> ? U : never) => boolean;
+export function propEq<T, K extends PropertyKey>(val: T, name: K): <U extends Partial<Record<K, any>>>(obj: Required<U> extends Record<K, any> ? T extends WidenLiterals<U[K]> ? U : never : never) => boolean;
 // propEq(val, name, obj)
 export function propEq<K extends keyof U, U>(val: U[K], name: K, obj: U): boolean;

--- a/types/propEq.d.ts
+++ b/types/propEq.d.ts
@@ -1,6 +1,40 @@
+import { Placeholder, WidenLiterals } from './util/tools';
+
+// propEq(val)
 export function propEq<T>(val: T): {
-  <K extends PropertyKey>(name: K): (obj: Record<K, T>) => boolean;
-  <K extends PropertyKey>(name: K, obj: Record<K, T>): boolean;
+  // propEq(val)(name)(obj)
+  <K extends PropertyKey>(name: K): (obj: Record<K, WidenLiterals<T>>) => boolean;
+  // propEq(val)(__, obj)(name)
+  <U>(__: Placeholder, obj: U): <K extends keyof U>(name: K) => U[K] extends WidenLiterals<T> ? boolean : never;
+  // propEq(val)(name, obj)
+  <K extends PropertyKey>(name: K, obj: Record<K, WidenLiterals<T>>): boolean;
 };
-export function propEq<T, K extends PropertyKey>(val: T, name: K): (obj: Record<K, T>) => boolean;
-export function propEq<K extends keyof U, U>(val: U[K], name: K, obj: U): boolean;
+
+// propEq(__, name)
+export function propEq<K extends PropertyKey>(__: Placeholder, name: K): {
+  // propEq(val)(obj)
+  <T>(val: T): (obj: Record<K, WidenLiterals<T>>) => boolean;
+  // propEq(__, obj)(val)
+  <U extends Record<K, any>>(__: Placeholder, obj: U): (val: WidenLiterals<U[K]>) => boolean;
+  // propEq(val, obj)
+  <T>(val: T, obj: Record<K, WidenLiterals<T>>): boolean;
+};
+// propEq(val, name)(obj)
+export function propEq<T, K extends PropertyKey>(val: T, name: K): (obj: Record<K, WidenLiterals<T>>) => boolean;
+
+// propEq(__, __, obj)
+export function propEq<U>(__: Placeholder, __2: Placeholder, obj: U): {
+  // propEq(__, __, obj)(val)(name)
+  <T>(val: T): <K extends keyof U>(name: K) => boolean;
+  // propEq(__, __, obj)(__, key)(name)
+  <K extends keyof U>(__: Placeholder, key: K): (val: WidenLiterals<U[K]>) => boolean;
+  // propEq(__, __, obj)(name, key)
+  <K extends keyof U>(val: WidenLiterals<U[K]>, name: K): boolean;
+};
+
+// propEq(__, name, obj)(val)
+export function propEq<K extends keyof U, U>(__: Placeholder, name: K, obj: U): (val: WidenLiterals<U[K]>) => boolean;
+// propEq(val, __, obj)(name)
+export function propEq<T, U>(val: T, __: Placeholder, obj: U): <K extends keyof U>(name: K) => U[K] extends WidenLiterals<T> ? boolean : never;
+// propEq(val, name, obj)
+export function propEq<K extends keyof U, U>(val: WidenLiterals<U[K]>, name: K, obj: U): boolean;

--- a/types/propEq.d.ts
+++ b/types/propEq.d.ts
@@ -3,12 +3,11 @@ import { WidenLiterals } from './util/tools';
 // propEq(val)
 export function propEq<T>(val: T): {
   // propEq(val)(name)(obj)
-  <K extends PropertyKey>(name: K): (obj: Record<K, WidenLiterals<T>>) => boolean;
+  <K extends PropertyKey>(name: K): <U extends Record<K, any>>(obj: T extends WidenLiterals<U[K]> ? U : never) => boolean;
   // propEq(val)(name, obj)
-  // type it this way for better error message for unknown keys
-  <K extends keyof U, U extends Record<PropertyKey, WidenLiterals<T>>>(name: K, obj: U): boolean;
+  <K extends keyof U, U extends Record<PropertyKey, any>>(name: K, obj: T extends WidenLiterals<U[K]> ? U : never): boolean;
 };
 // propEq(val, name)(obj)
-export function propEq<T, K extends PropertyKey>(val: T, name: K): (obj: Record<K, WidenLiterals<T>>) => boolean;
+export function propEq<T, K extends PropertyKey>(val: T, name: K): <U extends Record<K, any>>(obj: T extends WidenLiterals<U[K]> ? U : never) => boolean;
 // propEq(val, name, obj)
 export function propEq<K extends keyof U, U>(val: U[K], name: K, obj: U): boolean;

--- a/types/propEq.d.ts
+++ b/types/propEq.d.ts
@@ -1,12 +1,14 @@
+import { WidenLiterals } from './util/tools';
+
 // propEq(val)
-export function propEq<const T>(val: T): {
+export function propEq<T>(val: T): {
   // propEq(val)(name)(obj)
-  <K extends PropertyKey>(name: K): <U extends Partial<Record<K, any>>>(obj: Required<U> extends Record<K, any> ? T extends U[K] ? U : never : never) => boolean;
+  <K extends PropertyKey>(name: K): (obj: Record<K, WidenLiterals<T>>) => boolean;
   // propEq(val)(name, obj)
   // type it this way for better error message for unknown keys
-  <K extends keyof U, U extends Partial<Record<K, any>>>(name: K, obj: Required<U> extends Record<K, any> ? T extends U[K] ? U : never : never): boolean;
+  <K extends keyof U, U extends Record<PropertyKey, WidenLiterals<T>>>(name: K, obj: U): boolean;
 };
 // propEq(val, name)(obj)
-export function propEq<const T, K extends PropertyKey>(val: T, name: K): <U extends Partial<Record<K, any>>>(obj: Required<U> extends Record<K, any> ? T extends U[K] ? U : never : never) => boolean;
+export function propEq<T, K extends PropertyKey>(val: T, name: K): (obj: Record<K, WidenLiterals<T>>) => boolean;
 // propEq(val, name, obj)
 export function propEq<K extends keyof U, U>(val: U[K], name: K, obj: U): boolean;

--- a/types/propEq.d.ts
+++ b/types/propEq.d.ts
@@ -1,14 +1,12 @@
-import { WidenLiterals } from './util/tools';
-
 // propEq(val)
-export function propEq<T>(val: T): {
+export function propEq<const T>(val: T): {
   // propEq(val)(name)(obj)
-  <K extends PropertyKey>(name: K): <U extends Partial<Record<K, any>>>(obj: U) => T extends WidenLiterals<U[K]> ? boolean : never;
+  <K extends PropertyKey>(name: K): <U extends Partial<Record<K, any>>>(obj: Required<U> extends Record<K, any> ? T extends U[K] ? U : never : never) => boolean;
   // propEq(val)(name, obj)
   // type it this way for better error message for unknown keys
-  <K extends keyof U, U extends Partial<Record<PropertyKey, any>>>(name: K, obj: U): T extends WidenLiterals<U[K]> ? boolean : never;
+  <K extends keyof U, U extends Partial<Record<K, any>>>(name: K, obj: Required<U> extends Record<K, any> ? T extends U[K] ? U : never : never): boolean;
 };
 // propEq(val, name)(obj)
-export function propEq<T, K extends PropertyKey>(val: T, name: K): <U extends Partial<Record<PropertyKey, any>>>(obj: U) => T extends WidenLiterals<U[K]> ? boolean : never;
+export function propEq<const T, K extends PropertyKey>(val: T, name: K): <U extends Partial<Record<K, any>>>(obj: Required<U> extends Record<K, any> ? T extends U[K] ? U : never : never) => boolean;
 // propEq(val, name, obj)
 export function propEq<K extends keyof U, U>(val: U[K], name: K, obj: U): boolean;


### PR DESCRIPTION
See this playground for full tests: https://tsplay.dev/mMlMdN

`propEq` needs a lot of updating. This MR is one of 3 towards that effort.

This first effort is just to update the typings to allow for a more correct range of typing when passing a `val` without yet knowing the type of `obj`

tl;dr is that when we know the type of `val` but not the type of `obj`, we're allowing for a wider type range for better support. These additions fix the following issues that the current typings don't support:
* val is `string` but the prob type is `string | number`
* prop type is `| null` (eg nullable)
* prop type is optional

The downside to these changes is that we lose errors when the types at `obj.prop` don't at all overlap with the type of `val`, but it will return `never` in those cases, which is better than nothing

Since the we know the type of `val` and `obj` at the same time with the full function signature `propEq(val, name, obj)`, that signature can remain strict, since the above cases are not an issue with the full signature

TODO: update tests for `allPass` and `anyPass` so they don't rely on `propEq`. I don't want have to continuously update those as we update `propEq`. Those tests should stand on their own