### PR TITLE
Fix(prop): Allow optional props for prop(key)(obj) variety

### DIFF
--- a/test/prop.test.ts
+++ b/test/prop.test.ts
@@ -4,7 +4,7 @@ import { __, find, isNil, pipe, prop, sum, tap } from '../es';
 
 type Foo = {
   a: string;
-  b: number;
+  b?: number;
 };
 
 const foo: Foo = { a: '1', b: 2 };
@@ -12,11 +12,11 @@ const foo: Foo = { a: '1', b: 2 };
 // support objects
 foo.a;
 expectType<string>(prop('a')({} as Foo));
-expectType<number>(prop('b')({} as Foo));
+expectType<number | undefined>(prop('b')({} as Foo));
 expectType<string>(prop(__, {} as Foo)('a'));
-expectType<number>(prop(__, {} as Foo)('b'));
+expectType<number | undefined>(prop(__, {} as Foo)('b'));
 expectType<string>(prop('a', {} as Foo));
-expectType<number>(prop('b', {} as Foo));
+expectType<number | undefined>(prop('b', {} as Foo));
 
 // reject keys unknown in either direction
 // @ts-expect-error

--- a/types/prop.d.ts
+++ b/types/prop.d.ts
@@ -2,7 +2,7 @@
 import { Placeholder } from './util/tools';
 
 // prop(key)(obj)
-export function prop<K extends PropertyKey>(prop: K extends Placeholder ? never : K): <U extends Record<K, unknown>>(obj: U) => U[K];
+export function prop<K extends PropertyKey>(prop: K): <U extends { [P in K]?: unknown }>(obj: U) => U[K];
 // prop(__, obj)(key)
 export function prop<U>(__: Placeholder, obj: U): <K extends keyof U>(prop: K) => U[K];
 // prop(key, obj)


### PR DESCRIPTION
The way `prop(key)(obj)` was typed was `obj extends Record<K, unknown>`. From typescript's point of view, this means that the object must contain the key, but not if the key was optional. The constraint that `prop(key)(obj)` should have is that if the key exists on `obj`, optional or not. To fix, `Partial<Record<K, unknown>>` should be used. But that's a lot of characters, `{ [P in K]?: unknown }` is the exact same thing with less characters, so going with that