### PR TITLE
Fix(pick): Allow zero length array to be passed

### DIFF
--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -1,6 +1,6 @@
 import { expectType, expectError } from 'tsd';
 
-import { pick, KeysAsTuple } from '../es';
+import { pick } from '../es';
 
 const obj = { foo: 1, bar: '2', biz: false };
 
@@ -9,18 +9,16 @@ expectType<{ foo: number; }>(pick(['foo'])(obj));
 expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'])(obj));
 expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'])(obj));
 expectError(pick(['baz', 'bar', 'biz'])(obj));
+// make sure typed array works
+expectType<typeof obj>(pick([] as (keyof typeof obj)[])(obj));
 
 expectType<{}>(pick([], obj));
 expectType<{ foo: number; }>(pick(['foo'], obj));
 expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'], obj));
 expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'], obj));
 expectError(pick(['baz', 'bar', 'biz'], obj));
+// make sure typed array works
+expectType<typeof obj>(pick([] as (keyof typeof obj)[], obj));
 
 // Record
 expectType<Record<string, number>>(pick(['foo', 'bar'], {} as Record<string, number>));
-
-const names: string[] = ['foo', 'bar'];
-// in cases where names is either `string[]` or `(keyof obj)[]`, cast with supplied `KeysAsTuple` type function
-expectType<typeof obj>(pick(names as KeysAsTuple<typeof obj>, obj));
-// this case however is inaccurate, best to cast as a `Partial` in a real-world scenario
-expectType<Partial<typeof obj>>(pick(names as KeysAsTuple<typeof obj>, obj) as Partial<typeof obj>);

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -4,11 +4,13 @@ import { pick, KeysAsTuple } from '../es';
 
 const obj = { foo: 1, bar: '2', biz: false };
 
+expectType<{}>(pick([])(obj));
 expectType<{ foo: number; }>(pick(['foo'])(obj));
 expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'])(obj));
 expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'])(obj));
 expectError(pick(['baz', 'bar', 'biz'])(obj));
 
+expectType<{}>(pick([], obj));
 expectType<{ foo: number; }>(pick(['foo'], obj));
 expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'], obj));
 expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'], obj));

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -1,5 +1,5 @@
 import { ElementOf } from './util/tools';
 
-export function pick<const Names extends readonly [PropertyKey, ...PropertyKey[]]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
-export function pick<U, const Names extends readonly [keyof U, ...(keyof U)[]]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
+export function pick<const Names extends readonly PropertyKey[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
+export function pick<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
 

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -2,4 +2,3 @@ import { ElementOf } from './util/tools';
 
 export function pick<const Names extends readonly PropertyKey[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
 export function pick<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
-

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -508,10 +508,3 @@ export type WidenLiterals<T> =
  * <created by @harris-miller>
  */
 export type ElementOf<Type extends readonly any[]> = Type extends readonly (infer Values)[] ? Values : never;
-
-/**
- * Convenance type function to extract keys of an object as a tuple literal
- *
- * <created by @harris-miller>
- */
-export type KeysAsTuple<T> = [keyof T, ...(keyof T)[]];


### PR DESCRIPTION
Fixes: https://github.com/ramda/types/issues/76

The original typing for `pick` constrained the `names` array to have at least a length of 1 `[PropertyKey, ...PropertyKey[]]`. The reasoning behind this was to try and force the `names` to always be read as an array literal. The purpose was to directly return an object type with the specific values in `names` omited. This works well when you pass in an array literal or a typed tuple. However, that breaks down when you pass in a typed array.

```typescript
type Obj = { foo: string; bar: string; biz: string; baz: string };

// this worked fine because it was being read as an array literal
const r1 = pick(['foo', 'bar'], obj);
//    ^? { biz: string; baz: string }

const objKeys: (keyof Obj)[] = ['foo', 'bar'];

 // this fails because `objKeys` has an unknown length from a typing perspective
pick(objKeys, obj);
```

The fix is to simply update the typing to just be an array `PropertyKey[]`, length does not matter. It will still read correctly an array literal, but will also not breakdown when using a typed array

```typescript
type Obj = { foo: string; bar: string; biz: string; baz: string };

// this worked fine because it was being read as an array literal
const r1 = pick(['foo', 'bar'], obj);
//    ^? { biz: string; baz: string }

const objKeys: (keyof Obj)[] = ['foo', 'bar'];

// this works now, but the return type will not have any omited keys, because we don't know specifically what those keys are
const r2 = pick(objKeys, obj);
//    ^? Obj
```

Originally, I put in a helper type `KeysAsTuple` to make `(keyof Obj)[]` work, but I realized that
* even the with the best documentation people will never find this
* You don't need it anyways with this change