### PR TITLE
fix(path): Put back in curried signature for path function

### DIFF
--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -28,3 +28,8 @@ const somePath: string[] = ['one', 'two', 'three'];
 expectType<unknown>(path(somePath, obj));
 // typing the generic will give you a better return, but will always be unions with `unknown`
 expectType<Obj['one']['two']['three'] | unknown>(path<Obj['one']['two']['three']>(somePath, obj));
+
+// curried type allows for any, and allows you to set the return type in the generic
+// notice return type is based just on the generic and is always `| undefined`
+// the object passed into `obj` does not have to contain the actual path
+expectType<number | undefined>(path<number>(['a', 'b', 'c'])({}));

--- a/types/path.d.ts
+++ b/types/path.d.ts
@@ -1,5 +1,8 @@
 import { Path } from './util/tools';
 
+// need to evaluate how to do this curried, keep simple type for now
+export function path<T>(path: Path): (obj: any) => T | undefined;
+// full signatures
 export function path<S, K0 extends keyof S>(path: [K0], obj: S): S[K0];
 export function path<S, K0 extends keyof S, K1 extends keyof S[K0]>(path: [K0, K1], obj: S): S[K0][K1];
 export function path<


### PR DESCRIPTION
Was unintentionally removed in https://github.com/ramda/types/pull/66