### PR TITLE
stricter omit

### DIFF
--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -1,0 +1,28 @@
+import { expectType, expectError } from 'tsd';
+
+import { omit } from '../es';
+
+const obj = { foo: 1, bar: '2', biz: false };
+
+// curried
+
+expectType<typeof obj>(omit([])(obj));
+expectType<{ bar: string; biz: boolean; }>(omit(['foo'])(obj));
+expectType<{ biz: boolean; }>(omit(['foo', 'bar'])(obj));
+expectType<{}>(omit(['foo', 'bar', 'biz'])(obj));
+
+expectError(omit(['baz'])(obj));
+expectError(omit(['baz', 'bar', 'biz'])(obj));
+
+// non-curried
+
+expectType<typeof obj>(omit([], obj));
+expectType<{ bar: string; biz: boolean; }>(omit(['foo'], obj));
+expectType<{ biz: boolean; }>(omit(['foo', 'bar'], obj));
+expectType<{}>(omit(['foo', 'bar', 'biz'], obj));
+
+expectError(omit(['baz'], obj));
+expectError(omit(['baz', 'bar', 'biz'], obj));
+
+// Record
+expectType<Record<string, number>>(omit(['foo', 'bar'], {} as Record<string, number>));

--- a/types/omit.d.ts
+++ b/types/omit.d.ts
@@ -1,2 +1,2 @@
-export function omit<K extends string>(names: readonly K[]): <T>(obj: T) => Omit<T, K>;
-export function omit<T, K extends string>(names: readonly K[], obj: T): Omit<T, K>;
+export function omit<K extends string>(names: readonly K[]): <T extends { [Property in K]: any }>(obj: T) => Omit<T, K>;
+export function omit<T, K extends keyof T>(names: K[], obj: T): Omit<T, K>;

--- a/types/omit.d.ts
+++ b/types/omit.d.ts
@@ -1,4 +1,4 @@
 import { ElementOf } from './util/tools';
 
-export function omit<const Names extends readonly string[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => Omit<U, ElementOf<Names>>;
+export function omit<const Names extends readonly string[]>(names: Names): <U extends Partial<Record<ElementOf<Names>, any>>>(obj: U) => Omit<U, ElementOf<Names>>;
 export function omit<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): Omit<U, ElementOf<Names>>;

--- a/types/omit.d.ts
+++ b/types/omit.d.ts
@@ -1,2 +1,4 @@
-export function omit<K extends string>(names: readonly K[]): <T extends { [Property in K]: any }>(obj: T) => Omit<T, K>;
-export function omit<T, K extends keyof T>(names: K[], obj: T): Omit<T, K>;
+import { ElementOf } from './util/tools';
+
+export function omit<const Names extends readonly string[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => Omit<U, ElementOf<Names>>;
+export function omit<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): Omit<U, ElementOf<Names>>;


### PR DESCRIPTION
Makes `omit` stricter, in both curried and non-curried versions, by
- Non-curried: forcing the list of properties to actually be valid properties of the object
- Curried: forcing the object to have all the properties we want to omit

I've tested this in my own codebase. I still need to look into how to write tests for this with tsd (I'm new to tsd). All PR checks currently pass, but that's because there are no tests for `omit` yet.