### PR TITLE
Fix: `path`

### DIFF
--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -27,7 +27,7 @@ expectType<boolean>(path(['one', 'two', 'other'], obj));
 const somePath: string[] = ['one', 'two', 'three'];
 expectType<unknown>(path(somePath, obj));
 // typing the generic will give you a better return, but will always be unions with `unknown`
-expectType<Obj['one']['two']['three'] | unknown>(path<Obj['one']['two']['three']>(somePath, obj));
+expectType<Obj['one']['two']['three'] | undefined>(path<Obj['one']['two']['three']>(somePath, obj));
 
 // curried type allows for any, and allows you to set the return type in the generic
 // notice return type is based just on the generic and is always `| undefined`

--- a/types/path.d.ts
+++ b/types/path.d.ts
@@ -1,7 +1,7 @@
 import { Path } from './util/tools';
 
 // need to evaluate how to do this curried, keep simple type for now
-export function path<T>(path: Path): (obj: any) => T | undefined;
+export function path<T = unknown>(path: Path): (obj: any) => T | undefined;
 // full signatures
 export function path<S, K0 extends keyof S>(path: [K0], obj: S): S[K0];
 export function path<S, K0 extends keyof S, K1 extends keyof S[K0]>(path: [K0, K1], obj: S): S[K0][K1];
@@ -69,4 +69,4 @@ export function path<
   K8 extends keyof S[K0][K1][K2][K3][K4][K5][K6][K7]
 >(path: [K0, K1, K2, K3, K4, K5, K6, K7, K8], obj: S): S[K0][K1][K2][K3][K4][K5][K6][K7][K8];
 // final backup
-export function path<T>(path: Path, obj: any): T | unknown;
+export function path<T = unknown>(path: Path, obj: any): T | undefined;


### PR DESCRIPTION
Fixing an incorrect typing update that happened here: https://github.com/ramda/types/pull/66/files#diff-4177c11b548623dcf1336a333250de80491ee007ea784f5afa933909181a9b20R69

That should have been `| undefined`, not `| unknown`