### PR TITLE
Update: omit

### DIFF
--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -2,19 +2,24 @@ import { expectType, expectError } from 'tsd';
 
 import { omit } from '../es';
 
-const obj = { foo: 1, bar: '2', biz: false };
+type Obj = { foo: number; bar: string; biz?: boolean };
 
-expectType<{ foo: number; bar: string; biz: boolean; }>(omit([])(obj));
-expectType<{ bar: string; biz: boolean }>(omit(['foo'])(obj));
-expectType<{ biz: boolean }>(omit(['foo', 'bar'])(obj));
+const obj = {} as Obj;
+
+expectType<{ foo: number; bar: string; biz?: boolean; }>(omit([])(obj));
+expectType<{ bar: string; biz?: boolean }>(omit(['foo'])(obj));
+expectType<{ biz?: boolean }>(omit(['foo', 'bar'])(obj));
 expectType<{}>(omit(['foo', 'bar', 'biz'])(obj));
-expectError(omit(['baz', 'bar', 'biz'])(obj));
+// as long as some of the array has valid keys, it will accept it, but will return `never` if there are any invalid keys
+expectType<never>(omit(['baz', 'bar', 'biz'])(obj));
+// if the array is only invalid keys, it will error
+expectError(omit(['baz'])(obj));
 // make sure typed array works
 expectType<{}>(omit([] as (keyof typeof obj)[])(obj));
 
-expectType<{ foo: number; bar: string; biz: boolean; }>(omit([], obj));
-expectType<{ bar: string; biz: boolean }>(omit(['foo'], obj));
-expectType<{ biz: boolean }>(omit(['foo', 'bar'], obj));
+expectType<{ foo: number; bar: string; biz?: boolean; }>(omit([], obj));
+expectType<{ bar: string; biz?: boolean }>(omit(['foo'], obj));
+expectType<{ biz?: boolean }>(omit(['foo', 'bar'], obj));
 expectType<{}>(omit(['foo', 'bar', 'biz'], obj));
 expectError(omit(['baz', 'bar', 'biz'], obj));
 // make sure typed array works

--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -26,5 +26,5 @@ expectError(omit(['baz', 'bar', 'biz'], obj));
 expectType<{}>(omit([] as (keyof typeof obj)[], obj));
 
 // Record
-expectType<Record<string, number>>(omit(['foo', 'bar'])({} as Record<string, number>));
-expectType<Record<string, number>>(omit(['foo', 'bar'], {} as Record<string, number>));
+expectType<Omit<Record<string, number>, 'foo' | 'bar'>>(omit(['foo', 'bar'])({} as Record<string, number>));
+expectType<Omit<Record<string, number>, 'foo' | 'bar'>>(omit(['foo', 'bar'], {} as Record<string, number>));

--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -1,0 +1,24 @@
+import { expectType, expectError } from 'tsd';
+
+import { omit } from '../es';
+
+const obj = { foo: 1, bar: '2', biz: false };
+
+expectType<{ foo: number; bar: string; biz: boolean; }>(omit([])(obj));
+expectType<{ bar: string; biz: boolean }>(omit(['foo'])(obj));
+expectType<{ biz: boolean }>(omit(['foo', 'bar'])(obj));
+expectType<{}>(omit(['foo', 'bar', 'biz'])(obj));
+expectError(omit(['baz', 'bar', 'biz'])(obj));
+// make sure typed array works
+expectType<{}>(omit([] as (keyof typeof obj)[])(obj));
+
+expectType<{ foo: number; bar: string; biz: boolean; }>(omit([], obj));
+expectType<{ bar: string; biz: boolean }>(omit(['foo'], obj));
+expectType<{ biz: boolean }>(omit(['foo', 'bar'], obj));
+expectType<{}>(omit(['foo', 'bar', 'biz'], obj));
+expectError(omit(['baz', 'bar', 'biz'], obj));
+// make sure typed array works
+expectType<{}>(omit([] as (keyof typeof obj)[], obj));
+
+// Record
+expectType<Record<string, number>>(omit(['foo', 'bar'], {} as Record<string, number>));

--- a/test/omit.test.ts
+++ b/test/omit.test.ts
@@ -10,9 +10,9 @@ expectType<{ foo: number; bar: string; biz?: boolean; }>(omit([])(obj));
 expectType<{ bar: string; biz?: boolean }>(omit(['foo'])(obj));
 expectType<{ biz?: boolean }>(omit(['foo', 'bar'])(obj));
 expectType<{}>(omit(['foo', 'bar', 'biz'])(obj));
-// as long as some of the array has valid keys, it will accept it, but will return `never` if there are any invalid keys
-expectType<never>(omit(['baz', 'bar', 'biz'])(obj));
-// if the array is only invalid keys, it will error
+// errors with `never` if array contains some but not all keys on obj
+expectError(omit(['baz', 'bar', 'biz'])(obj));
+// errors (with better message) with array of all unknown keys
 expectError(omit(['baz'])(obj));
 // make sure typed array works
 expectType<{}>(omit([] as (keyof typeof obj)[])(obj));
@@ -26,4 +26,5 @@ expectError(omit(['baz', 'bar', 'biz'], obj));
 expectType<{}>(omit([] as (keyof typeof obj)[], obj));
 
 // Record
+expectType<Record<string, number>>(omit(['foo', 'bar'])({} as Record<string, number>));
 expectType<Record<string, number>>(omit(['foo', 'bar'], {} as Record<string, number>));

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -2,20 +2,25 @@ import { expectType, expectError } from 'tsd';
 
 import { pick } from '../es';
 
-const obj = { foo: 1, bar: '2', biz: false };
+type Obj = { foo: number; bar: string; biz?: boolean };
+
+const obj = {} as Obj;
 
 expectType<{}>(pick([])(obj));
 expectType<{ foo: number; }>(pick(['foo'])(obj));
 expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'])(obj));
-expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'])(obj));
-expectError(pick(['baz', 'bar', 'biz'])(obj));
+expectType<{ foo: number; bar: string; biz?: boolean }>(pick(['foo', 'bar', 'biz'])(obj));
+// as long as some of the array has valid keys, it will accept it, but will return `never` if there are any invalid keys
+expectType<never>(pick(['baz', 'bar', 'biz'])(obj));
+// if the array is only invalid keys, it will error
+expectError(pick(['baz'])(obj));
 // make sure typed array works
 expectType<typeof obj>(pick([] as (keyof typeof obj)[])(obj));
 
 expectType<{}>(pick([], obj));
 expectType<{ foo: number; }>(pick(['foo'], obj));
 expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'], obj));
-expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'], obj));
+expectType<{ foo: number; bar: string; biz?: boolean }>(pick(['foo', 'bar', 'biz'], obj));
 expectError(pick(['baz', 'bar', 'biz'], obj));
 // make sure typed array works
 expectType<typeof obj>(pick([] as (keyof typeof obj)[], obj));

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -11,7 +11,7 @@ expectType<{ foo: number; }>(pick(['foo'])(obj));
 expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'])(obj));
 expectType<{ foo: number; bar: string; biz?: boolean }>(pick(['foo', 'bar', 'biz'])(obj));
 // as long as some of the array has valid keys, it will accept it, but will return `never` if there are any invalid keys
-expectType<never>(pick(['baz', 'bar', 'biz'])(obj));
+expectError(pick(['baz', 'bar', 'biz'])(obj));
 // if the array is only invalid keys, it will error
 expectError(pick(['baz'])(obj));
 // make sure typed array works

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -26,5 +26,5 @@ expectError(pick(['baz', 'bar', 'biz'], obj));
 expectType<typeof obj>(pick([] as (keyof typeof obj)[], obj));
 
 // Record
-expectType<Record<string, number>>(pick(['foo', 'bar'])({} as Record<string, number>));
-expectType<Record<string, number>>(pick(['foo', 'bar'], {} as Record<string, number>));
+expectType<Pick<Record<string, number>, 'foo' | 'bar'>>(pick(['foo', 'bar'])({} as Record<string, number>));
+expectType<Pick<Record<string, number>, 'foo' | 'bar'>>(pick(['foo', 'bar'], {} as Record<string, number>));

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -12,7 +12,7 @@ expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'])(obj));
 expectType<{ foo: number; bar: string; biz?: boolean }>(pick(['foo', 'bar', 'biz'])(obj));
 // as long as some of the array has valid keys, it will accept it, but will return `never` if there are any invalid keys
 expectError(pick(['baz', 'bar', 'biz'])(obj));
-// if the array is only invalid keys, it will error
+// errors (with better message) with array of all unknown keys
 expectError(pick(['baz'])(obj));
 // make sure typed array works
 expectType<typeof obj>(pick([] as (keyof typeof obj)[])(obj));
@@ -26,4 +26,5 @@ expectError(pick(['baz', 'bar', 'biz'], obj));
 expectType<typeof obj>(pick([] as (keyof typeof obj)[], obj));
 
 // Record
+expectType<Record<string, number>>(pick(['foo', 'bar'])({} as Record<string, number>));
 expectType<Record<string, number>>(pick(['foo', 'bar'], {} as Record<string, number>));

--- a/types/omit.d.ts
+++ b/types/omit.d.ts
@@ -1,4 +1,4 @@
 import { ElementOf } from './util/tools';
 
-export function omit<const Names extends readonly PropertyKey[]>(names: Names): <U extends Partial<Record<ElementOf<Names>, any>>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : ElementOf<Names> extends keyof U ? Omit<U, ElementOf<Names>> : never;
+export function omit<const Keys extends readonly PropertyKey[]>(names: Keys): <U extends Partial<Record<ElementOf<Keys>, any>>>(obj: ElementOf<Keys> extends keyof U ? U : never) => ElementOf<Keys> extends keyof U ? Omit<U, ElementOf<Keys>> : never;
 export function omit<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Omit<U, ElementOf<Names>>;

--- a/types/omit.d.ts
+++ b/types/omit.d.ts
@@ -1,2 +1,4 @@
-export function omit<K extends string>(names: readonly K[]): <T>(obj: T) => Omit<T, K>;
-export function omit<T, K extends string>(names: readonly K[], obj: T): Omit<T, K>;
+import { ElementOf } from './util/tools';
+
+export function omit<const Names extends readonly PropertyKey[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Omit<U, ElementOf<Names>>;
+export function omit<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Omit<U, ElementOf<Names>>;

--- a/types/omit.d.ts
+++ b/types/omit.d.ts
@@ -1,4 +1,4 @@
 import { ElementOf } from './util/tools';
 
-export function omit<const Names extends readonly PropertyKey[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Omit<U, ElementOf<Names>>;
+export function omit<const Names extends readonly PropertyKey[]>(names: Names): <U extends Partial<Record<ElementOf<Names>, any>>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : ElementOf<Names> extends keyof U ? Omit<U, ElementOf<Names>> : never;
 export function omit<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Omit<U, ElementOf<Names>>;

--- a/types/omit.d.ts
+++ b/types/omit.d.ts
@@ -1,4 +1,4 @@
 import { ElementOf } from './util/tools';
 
 export function omit<const Keys extends readonly PropertyKey[]>(names: Keys): <U extends Partial<Record<ElementOf<Keys>, any>>>(obj: ElementOf<Keys> extends keyof U ? U : never) => ElementOf<Keys> extends keyof U ? Omit<U, ElementOf<Keys>> : never;
-export function omit<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Omit<U, ElementOf<Names>>;
+export function omit<U, Keys extends keyof U>(names: readonly Keys[], obj: U): Omit<U, Keys>;

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -1,4 +1,4 @@
 import { ElementOf } from './util/tools';
 
-export function pick<const Names extends readonly PropertyKey[]>(names: Names): <U extends Partial<Record<ElementOf<Names>, any>>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : ElementOf<Names> extends keyof U ? Pick<U, ElementOf<Names>> : never;
-export function pick<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
+export function pick<const Keys extends readonly PropertyKey[]>(names: Keys): <U extends Partial<Record<ElementOf<Keys>, any>>>(obj: ElementOf<Keys> extends keyof U ? U : never) => ElementOf<Keys> extends keyof U ? Pick<U, ElementOf<Keys>> : never;
+export function pick<U, Keys extends keyof U>(names: readonly Keys[], obj: U): Pick<U, Keys>;

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -1,4 +1,4 @@
 import { ElementOf } from './util/tools';
 
-export function pick<const Names extends readonly PropertyKey[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
+export function pick<const Names extends readonly PropertyKey[]>(names: Names): <U extends Partial<Record<ElementOf<Names>, any>>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : ElementOf<Names> extends keyof U ? Pick<U, ElementOf<Names>> : never;
 export function pick<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;


### PR DESCRIPTION
typing `omit` same as `pick`

Additional fix for optional properties for `pick`