### PR TITLE
fix(pick): update for ts4 support

### DIFF
--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -2,23 +2,52 @@ import { expectType, expectError } from 'tsd';
 
 import { pick } from '../es';
 
-const obj = { foo: 1, bar: '2', biz: false };
+type Obj = { foo: number, bar: string, biz: boolean, baz: Date; a: string; b: string; c: string; d: string, e: string };
+const obj = {} as Obj;
 
-expectType<{}>(pick([])(obj));
-expectType<{ foo: number; }>(pick(['foo'])(obj));
-expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'])(obj));
-expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'])(obj));
-expectError(pick(['baz', 'bar', 'biz'])(obj));
-// make sure typed array works
-expectType<typeof obj>(pick([] as (keyof typeof obj)[])(obj));
+expectType<Pick<Obj, never>>(pick([])(obj));
+expectType<Pick<Obj, 'foo'>>(pick(['foo'])(obj));
+expectType<Pick<Obj, 'foo' | 'bar'>>(pick(['foo', 'bar'])(obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz'>>(pick(['foo', 'bar', 'biz'])(obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz'>>(pick(['foo', 'bar', 'biz', 'baz'])(obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a'>>(pick(['foo', 'bar', 'biz', 'baz', 'a'])(obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b'])(obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c'])(obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c' | 'd'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd'])(obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c' | 'd' | 'e'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'] as const)(obj));
+// this technically works, however doesn't give you any useful and should be avoided, also use `as const` instead
+expectType<Pick<Obj, keyof Obj>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'])(obj));
+expectError(pick(['what'])(obj));
 
-expectType<{}>(pick([], obj));
-expectType<{ foo: number; }>(pick(['foo'], obj));
-expectType<{ foo: number; bar: string; }>(pick(['foo', 'bar'], obj));
-expectType<{ foo: number; bar: string; biz: boolean }>(pick(['foo', 'bar', 'biz'], obj));
-expectError(pick(['baz', 'bar', 'biz'], obj));
-// make sure typed array works
-expectType<typeof obj>(pick([] as (keyof typeof obj)[], obj));
+expectType<Pick<Obj, never>>(pick([], obj));
+expectType<Pick<Obj, 'foo'>>(pick(['foo'], obj));
+expectType<Pick<Obj, 'foo' | 'bar'>>(pick(['foo', 'bar'], obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz'>>(pick(['foo', 'bar', 'biz'], obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz'>>(pick(['foo', 'bar', 'biz', 'baz'], obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a'>>(pick(['foo', 'bar', 'biz', 'baz', 'a'], obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b'], obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c'], obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c' | 'd'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd'], obj));
+expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c' | 'd' | 'e'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'] as const, obj));
+expectError(pick(['what'], obj));
 
-// Record
+expectType<Record<string, number>>(pick(['foo'])({} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar'])({} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz'])({} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz'])({} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a'])({} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b'])({} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c'])({} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd'])({} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'] as const)({} as Record<string, number>));
+
+expectType<Record<string, number>>(pick([], {} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo'], {} as Record<string, number>));
 expectType<Record<string, number>>(pick(['foo', 'bar'], {} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz'], {} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz'], {} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a'], {} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b'], {} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c'], {} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd'], {} as Record<string, number>));
+expectType<Record<string, number>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'], {} as Record<string, number>));

--- a/test/pick.test.ts
+++ b/test/pick.test.ts
@@ -1,4 +1,4 @@
-import { expectType, expectError } from 'tsd';
+import { expectType, expectError, expectAssignable } from 'tsd';
 
 import { pick } from '../es';
 
@@ -15,8 +15,11 @@ expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b'>>(pick(['foo', 'b
 expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c'])(obj));
 expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c' | 'd'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd'])(obj));
 expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c' | 'd' | 'e'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'] as const)(obj));
-// this technically works, however doesn't give you any useful and should be avoided, also use `as const` instead
-expectType<Pick<Obj, keyof Obj>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'])(obj));
+
+// while these technically work, they give back false positives, avoid their use
+expectAssignable<Pick<Obj, keyof Obj>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'])(obj));
+expectType<Pick<Obj, keyof Obj>>(pick([] as (keyof Obj)[])(obj));
+
 expectError(pick(['what'])(obj));
 
 expectType<Pick<Obj, never>>(pick([], obj));
@@ -29,6 +32,10 @@ expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b'>>(pick(['foo', 'b
 expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c'], obj));
 expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c' | 'd'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd'], obj));
 expectType<Pick<Obj, 'foo' | 'bar' | 'biz' | 'baz' | 'a' | 'b' | 'c' | 'd' | 'e'>>(pick(['foo', 'bar', 'biz', 'baz', 'a', 'b', 'c', 'd', 'e'] as const, obj));
+
+// while this technically work, they give back false positives, avoid their use
+expectType<Pick<Obj, keyof Obj>>(pick([] as (keyof Obj)[], obj));
+
 expectError(pick(['what'], obj));
 
 expectType<Record<string, number>>(pick(['foo'])({} as Record<string, number>));

--- a/types/pick.d.ts
+++ b/types/pick.d.ts
@@ -1,4 +1,58 @@
 import { ElementOf } from './util/tools';
 
-export function pick<const Names extends readonly PropertyKey[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
-export function pick<U, const Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
+export function pick<
+  T1 extends PropertyKey
+>(names: [T1]): <U extends Record<T1, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, T1>;
+export function pick<
+  T1 extends PropertyKey,
+  T2 extends PropertyKey
+>(names: [T1, T2]): <U extends Record<T1 | T2, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, T1 | T2>;
+export function pick<
+  T1 extends PropertyKey,
+  T2 extends PropertyKey,
+  T3 extends PropertyKey
+>(names: [T1, T2, T3]): <U extends Record<T1 | T2 | T3, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, T1 | T2 | T3>;
+export function pick<
+  T1 extends PropertyKey,
+  T2 extends PropertyKey,
+  T3 extends PropertyKey,
+  T4 extends PropertyKey
+>(names: [T1, T2, T3, T4]): <U extends Record<T1 | T2 | T3 | T4, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, T1 | T2 | T3 | T4>;
+export function pick<
+  T1 extends PropertyKey,
+  T2 extends PropertyKey,
+  T3 extends PropertyKey,
+  T4 extends PropertyKey,
+  T5 extends PropertyKey
+>(names: [T1, T2, T3, T4, T5]): <U extends Record<T1 | T2 | T3 | T4 | T5, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, T1 | T2 | T3 | T4 | T5>;
+export function pick<
+  T1 extends PropertyKey,
+  T2 extends PropertyKey,
+  T3 extends PropertyKey,
+  T4 extends PropertyKey,
+  T5 extends PropertyKey,
+  T6 extends PropertyKey
+>(names: [T1, T2, T3, T4, T5, T6]): <U extends Record<T1 | T2 | T3 | T4 | T5 | T6, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, T1 | T2 | T3 | T4 | T5 | T6>;
+export function pick<
+  T1 extends PropertyKey,
+  T2 extends PropertyKey,
+  T3 extends PropertyKey,
+  T4 extends PropertyKey,
+  T5 extends PropertyKey,
+  T6 extends PropertyKey,
+  T7 extends PropertyKey
+>(names: [T1, T2, T3, T4, T5, T6, T7]): <U extends Record<T1 | T2 | T3 | T4 | T5 | T6 | T7, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, T1 | T2 | T3 | T4 | T5 | T6 | T7>;
+export function pick<
+  T1 extends PropertyKey,
+  T2 extends PropertyKey,
+  T3 extends PropertyKey,
+  T4 extends PropertyKey,
+  T5 extends PropertyKey,
+  T6 extends PropertyKey,
+  T7 extends PropertyKey,
+  T8 extends PropertyKey
+>(names: [T1, T2, T3, T4, T5, T6, T7, T8]): <U extends Record<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
+// back up for over 9, will require `as const` to work
+export function pick<Names extends readonly PropertyKey[]>(names: Names): <U extends Record<ElementOf<Names>, any>>(obj: U) => string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;
+// because we can extend (keyof U)(), `names` always gets read as a union of the values, so we don't need to overload these!
+export function pick<U, Names extends readonly (keyof U)[]>(names: Names, obj: U): string extends keyof U ? Record<string, U[keyof U]> : Pick<U, ElementOf<Names>>;


### PR DESCRIPTION
The current type def utilizes `const` in the generic, which is ts5 only. I discovered you can get the same desired effect with verbose tuple definitions