### PR TITLE
feat(zipObj): stricter types, add test

### DIFF
--- a/test/zipObj.test.ts
+++ b/test/zipObj.test.ts
@@ -11,6 +11,7 @@ expectType<{bool: boolean, number: number}>(zipObj(['bool', 'number'], [true, 1]
 expectType<{[key: string]: boolean}>(zipObj(['a'] as string[], [true, false] as boolean[]));
 expectType<{a: boolean}>(zipObj(['a'], [true, false] as boolean[]));
 expectType<{[key: string]: boolean}>(zipObj(['a'] as string[], [true, false]));
+expectType<{[key: string]: boolean | number | string}>(zipObj(['a', 'b', 'c'] as string[], [true, 1, 'a']));
 expectType<{bool: true, number: 1}>(zipObj(['bool', 'number'], [true, 1, 'string']));
 expectType<{bool: true, number: 1, missing: undefined}>(zipObj(['bool', 'number', 'missing'], [true, 1]));
 

--- a/test/zipObj.test.ts
+++ b/test/zipObj.test.ts
@@ -1,0 +1,24 @@
+import { expectType } from 'tsd';
+import { zipObj } from '../types/zipObj';
+
+const sym = Symbol.for('Symbol');
+
+// zipObj(key, values)
+expectType<{bool: true, number: 1, null: null, undefined: undefined}>(zipObj(['bool', 'number', 'null', 'undefined'], [true, 1, null, undefined]));
+expectType<{1: 1, [sym]: symbol}>(zipObj([1, sym], [1, sym]));
+expectType<{bool: boolean, number: number}>(zipObj(['bool', 'number'], [true, 1] as [boolean, number]));
+expectType<{[key: string]: boolean}>(zipObj(['a'] as string[], [true, false] as boolean[]));
+expectType<{a: boolean}>(zipObj(['a'], [true, false] as boolean[]));
+expectType<{[key: string]: boolean}>(zipObj(['a'] as string[], [true, false]));
+expectType<{bool: true, number: 1}>(zipObj(['bool', 'number'], [true, 1, 'string']));
+expectType<{bool: true, number: 1, missing: undefined}>(zipObj(['bool', 'number', 'missing'], [true, 1]));
+
+// zipObj(key)(values)
+expectType<{bool: true, number: 1, null: null, undefined: undefined}>(zipObj(['bool', 'number', 'null', 'undefined'])([true, 1, null, undefined]));
+expectType<{1: 1, [sym]: symbol}>(zipObj([1, sym])([1, sym]));
+expectType<{bool: boolean, number: number}>(zipObj(['bool', 'number'])([true, 1] as [boolean, number]));
+expectType<{[key: string]: boolean}>(zipObj(['a'] as string[])([true, false] as boolean[]));
+expectType<{a: boolean}>(zipObj(['a'])([true, false] as boolean[]));
+expectType<{[key: string]: boolean}>(zipObj(['a'] as string[])([true, false]));
+expectType<{bool: true, number: 1}>(zipObj(['bool', 'number'])([true, 1, 'string']));
+expectType<{bool: true, number: 1, missing: undefined}>(zipObj(['bool', 'number', 'missing'])([true, 1]));

--- a/test/zipObj.test.ts
+++ b/test/zipObj.test.ts
@@ -11,7 +11,7 @@ expectType<{bool: boolean, number: number}>(zipObj(['bool', 'number'], [true, 1]
 expectType<{[key: string]: boolean}>(zipObj(['a'] as string[], [true, false] as boolean[]));
 expectType<{a: boolean}>(zipObj(['a'], [true, false] as boolean[]));
 expectType<{[key: string]: boolean}>(zipObj(['a'] as string[], [true, false]));
-expectType<{[key: string]: boolean | number | string}>(zipObj(['a', 'b', 'c'] as string[], [true, 1, 'a']));
+expectType<{[key: string]: boolean | number | string}>(zipObj(['a', 'b', 'c'] as string[], [true, 1, 'a'] as (string | number | boolean)[]));
 expectType<{bool: true, number: 1}>(zipObj(['bool', 'number'], [true, 1, 'string']));
 expectType<{bool: true, number: 1, missing: undefined}>(zipObj(['bool', 'number', 'missing'], [true, 1]));
 

--- a/test/zipObj.test.ts
+++ b/test/zipObj.test.ts
@@ -1,5 +1,6 @@
 import { expectType } from 'tsd';
 import { zipObj } from '../types/zipObj';
+import { pipe } from '../types/pipe';
 
 const sym = Symbol.for('Symbol');
 
@@ -22,3 +23,9 @@ expectType<{a: boolean}>(zipObj(['a'])([true, false] as boolean[]));
 expectType<{[key: string]: boolean}>(zipObj(['a'] as string[])([true, false]));
 expectType<{bool: true, number: 1}>(zipObj(['bool', 'number'])([true, 1, 'string']));
 expectType<{bool: true, number: 1, missing: undefined}>(zipObj(['bool', 'number', 'missing'])([true, 1]));
+
+
+expectType<{string: string, number: number}>(pipe(
+  (a: [string, number]) => a,
+  zipObj(['string', 'number'])
+)(['a', 42]));

--- a/types/util/zipObj.d.ts
+++ b/types/util/zipObj.d.ts
@@ -1,0 +1,7 @@
+import * as _ from 'ts-toolbelt';
+
+export type _ZipObj<K extends readonly PropertyKey[], V extends {[key in keyof K]: unknown} | readonly unknown[]> =
+    number extends V['length'] ?
+      { [T in K[number]]: V[number] } :
+      number extends K['length'] ?
+        { [T in K[number]]: V[number] } : _.L.ZipObj<K, V>;

--- a/types/zipObj.d.ts
+++ b/types/zipObj.d.ts
@@ -1,10 +1,5 @@
 import * as _ from 'ts-toolbelt';
-
-export type _ZipObj<K extends readonly PropertyKey[], V extends {[key in keyof K]: unknown} | readonly unknown[]> =
-    number extends V['length'] ?
-      { [T in K[number]]: V[number] } :
-      number extends K['length'] ?
-        { [T in K[number]]: V[number] } : _.L.ZipObj<K, V>;
+import { _ZipObj } from './util/zipObj';
 
 export function zipObj<K extends readonly PropertyKey[]>(keys: _.F.Narrow<K>):
 <V extends {[key in keyof K]: unknown} | readonly unknown[]>(values: _.F.Narrow<V>) =>

--- a/types/zipObj.d.ts
+++ b/types/zipObj.d.ts
@@ -1,3 +1,14 @@
-export function zipObj<K extends PropertyKey>(keys: readonly K[]): <T>(values: readonly T[]) => { [P in K]: T };
-export function zipObj<T, K extends PropertyKey>(keys: readonly K[], values: readonly T[]): { [P in K]: T };
+import * as _ from 'ts-toolbelt';
 
+export type _ZipObj<K extends readonly PropertyKey[], V extends {[key in keyof K]: unknown} | readonly unknown[]> =
+    number extends V['length'] ?
+      { [T in K[number]]: V[number] } :
+      number extends K['length'] ?
+        { [T in K[number]]: V[number] } : _.L.ZipObj<K, V>;
+
+export function zipObj<K extends readonly PropertyKey[]>(keys: _.F.Narrow<K>):
+<V extends {[key in keyof K]: unknown} | readonly unknown[]>(values: _.F.Narrow<V>) =>
+_ZipObj<K, V>;
+
+export function zipObj<K extends readonly PropertyKey[], V extends {[key in keyof K]: unknown} | readonly unknown[]>(keys: _.F.Narrow<K>, values: _.F.Narrow<V>):
+_ZipObj<K, V>;


### PR DESCRIPTION
Narrow values types per key when possible, otherwise fallback on wider mapped type.

Tests included