### PR TITLE
fix(groupBy) do not return wrapped in `Partial<>`

### DIFF
--- a/test/groupBy.test.ts
+++ b/test/groupBy.test.ts
@@ -1,5 +1,5 @@
-import { expectType } from 'tsd';
-import { groupBy, __ } from '../es';
+import { expectError, expectType } from 'tsd';
+import { toPairs, groupBy, __ } from '../es';
 
 type Student = { score: number; name: string };
 
@@ -24,3 +24,8 @@ const grouped2 = byGrade2((student: Student) => {
   return score < 65 ? 'F' : score < 70 ? 'D' : score < 80 ? 'C' : score < 90 ? 'B' : 'A';
 });
 expectType<Record<'A' | 'B' | 'C' | 'D' | 'F', Student[]>>(grouped2);
+
+// toPairs returns expected
+const entries = toPairs({} as Record<string, Student[]>);
+expectType<[string, Student[]][]>(entries);
+expectError<[string, Student[] | undefined][]>(entries); // this assertion was true before when groupBy returned `Partial<Record<>>`

--- a/test/groupBy.test.ts
+++ b/test/groupBy.test.ts
@@ -1,29 +1,26 @@
 import { expectType } from 'tsd';
 import { groupBy, __ } from '../es';
 
-// returns optional arrays for the groups
+type Student = { score: number; name: string };
 
-const byGrade = groupBy((student: { score: number; name: string }) => {
+const byGrade = groupBy((student: Student) => {
   const score = student.score;
   return score < 65 ? 'F' : score < 70 ? 'D' : score < 80 ? 'C' : score < 90 ? 'B' : 'A';
 });
+
 const students = [
   { name: 'Abby', score: 84 },
   { name: 'Eddy', score: 58 },
   { name: 'Jack', score: 69 }
 ];
 
-const grouped = byGrade(students);
-expectType<{ score: number; name: string }[] | undefined>(grouped.C);
-(grouped.C ?? []).length;
-// @ts-expect-error
-grouped.C.length;
+expectType<Record<'A' | 'B' | 'C' | 'D' | 'F', Student[]>>(byGrade(students));
 
 // accepts a placeholder and later specifying the grouping function
 
 const byGrade2 = groupBy(__, students);
-const grouped2 = byGrade2((student: { score: number; name: string }) => {
+const grouped2 = byGrade2((student: Student) => {
   const score = student.score;
   return score < 65 ? 'F' : score < 70 ? 'D' : score < 80 ? 'C' : score < 90 ? 'B' : 'A';
 });
-expectType<{ score: number; name: string }[] | undefined>(grouped2.C);
+expectType<Record<'A' | 'B' | 'C' | 'D' | 'F', Student[]>>(grouped2);

--- a/types/groupBy.d.ts
+++ b/types/groupBy.d.ts
@@ -1,5 +1,5 @@
 import { Placeholder } from './util/tools';
 
-export function groupBy<T, K extends string = string>(fn: (a: T) => K): (list: readonly T[]) => Partial<Record<K, T[]>>;
-export function groupBy<T>(__: Placeholder, list: readonly T[]): <K extends string = string>(fn: (a: T) => K) => Partial<Record<K, T[]>>;
-export function groupBy<T, K extends string = string>(fn: (a: T) => K, list: readonly T[]): Partial<Record<K, T[]>>;
+export function groupBy<T, K extends string = string>(fn: (a: T) => K): (list: readonly T[]) => Record<K, T[]>;
+export function groupBy<T>(__: Placeholder, list: readonly T[]): <K extends string = string>(fn: (a: T) => K) => Record<K, T[]>;
+export function groupBy<T, K extends string = string>(fn: (a: T) => K, list: readonly T[]): Record<K, T[]>;


### PR DESCRIPTION
A previous MR https://github.com/ramda/types/pull/45 added to the return of `groupBy` that it should be wrapped in `Partial<>`. This makes a lot of sense in the fact that the function could return keys that don't actually exist on the object it creates.

Using the example from Ramda docs
```typescript
const byGrade = groupBy((student: { score: number; name: string }) => {
  const score = student.score;
  return score < 65 ? 'F' : score < 70 ? 'D' : score < 80 ? 'C' : score < 90 ? 'B' : 'A';
});
const students = [
  { name: 'Abby', score: 84 },
  { name: 'Eddy', score: 58 },
  { name: 'Jack', score: 69 }
];
```
The type that `byGrade(students)` returned previously was `Record<'A' | 'B' | 'C' | 'D' | 'F', Student[]>`, which was accurate, but also misleading, because there was no guarantee at runtime that each of the union values existed as a key. This is why the `Partial<>` as added.

**6 months later**

HIndsight is 20/20 and we've come to learn that wrapping in `Partial<>` breaks other functionality in terms of mapping to other things. `toPairs` is a prime example.
```typescript
const entries = toPairs(groupBy(students));
```
The return type previously was `[<'A' | 'B' | 'C' | 'D' | 'F', Student[] | undefined][]`. The `| undefined` is a problem. Because that it more inaccurate for runtime behavior that index accessing on `Record<string, Student[]>`

Typescript also allows for what we were trying to solve here via the tsconfig option [https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess](noUncheckedIndexedAccess). Which if set gives a project a correct `Students[] | undefined` from index accessing `Record<string, Students[]>`. Which IMHO should be the default behavior for `Record<>`

This MR removes the `Partial<>` wrap in the return to account for this undesired behavior.