### PR TITLE
Revert "Update: propEq to allow wider-typing for value in comparison"

### DIFF
--- a/test/allPass.test.ts
+++ b/test/allPass.test.ts
@@ -48,21 +48,3 @@ expectError(
     nickname: 'Blade'
   })
 );
-
-const isQueen = propEq('Q', 'rank');
-const isSpade = propEq('♠︎', 'suit');
-const isQueenOfSpades = allPass([isQueen, isSpade]);
-
-isQueenOfSpades({
-  rank: '2',
-  suit: '♠︎'
-});
-
-const isQueen2 = (x: Record<'rank', string>) => x.rank === 'Q';
-const isSpade2 = (x: Record<'suit', string>) => x.suit === '♠︎';
-const isQueenOfSpades2 = allPass([isQueen2, isSpade2]);
-
-isQueenOfSpades2({
-  rank: '2',
-  suit: '♠︎'
-});

--- a/test/anyPass.test.ts
+++ b/test/anyPass.test.ts
@@ -25,13 +25,13 @@ expectType<boolean>(
   })
 );
 
-expectType<boolean>(
+expectError(
   isVampire({
     age: 21,
     garlic_allergy: true,
     sun_allergy: true,
-    fast: null,
-    fear: undefined
+    fast: false,
+    fear: true
   })
 );
 
@@ -48,26 +48,3 @@ expectError(
     nickname: 'Blade'
   })
 );
-
-const isQueen = propEq('Q', 'rank');
-const isSpade = propEq('♠︎', 'suit');
-const isQueenOfSpades = anyPass([isQueen, isSpade]);
-
-expectType<boolean>(isQueenOfSpades({
-  rank: '2',
-  suit: '♠︎'
-}));
-
-expectError(isQueenOfSpades({
-  rank: 2,
-  suit: '♠︎'
-}));
-
-const isQueen2 = (x: Record<'rank', string>) => x.rank === 'Q';
-const isSpade2 = (x: Record<'suit', string>) => x.suit === '♠︎';
-const isQueenOfSpades2 = anyPass([isQueen2, isSpade2]);
-
-isQueenOfSpades2({
-  rank: '2',
-  suit: '♠︎'
-});

--- a/test/propEq.test.ts
+++ b/test/propEq.test.ts
@@ -3,153 +3,37 @@ import { expectError, expectType } from 'tsd';
 import { propEq } from '../es';
 
 type Obj = {
-  literals: 'A' | 'B';
-  unions: number | string;
-  nullable: number | null | undefined;
-  optional?: number;
+  union: 'foo' | 'bar';
+  str: string;
+  num: number;
+  u: undefined;
+  n: null;
 };
 
-const obj = {} as Obj;
+// propEq(val, name, obj)
+expectType<boolean>(propEq('foo', 'union', {} as Obj));
+// non-union string fails
+expectError(propEq('nope', 'union', {} as Obj));
+// completely different type fails
+expectError(propEq(2, 'union', {} as Obj));
 
-//
-// literals
-//
+// propEq(val)(name)(obj)
+expectType<boolean>(propEq('foo')('union')({} as Obj));
+// 'nope' is inferred as 'string' here.
+expectType<boolean>(propEq('nope')('union')({} as Obj));
+// completely different type fails
+expectError(propEq(2)('union')({} as Obj));
 
-// happy path works as expected
-expectType<boolean>(propEq('A')('literals')(obj));
-expectType<boolean>(propEq('A', 'literals')(obj));
-expectType<boolean>(propEq('A', 'literals', obj));
+// propEq(val)(name), obj)
+expectType<boolean>(propEq('foo')('union', {} as Obj));
+// 'nope' is inferred as 'string' here.
+expectType<boolean>(propEq('nope')('union', {} as Obj));
+// completely different type fails
+expectError(propEq(2)('union', {} as Obj));
 
-// accepts any type that obj[key] can be widened too
-expectType<boolean>(propEq('C')('literals')(obj));
-expectType<boolean>(propEq('C', 'literals')(obj));
-// only propEq(val, key, obj) requests non-widened types
-expectError(propEq('C', 'literals', obj));
-
-// rejects if type cannot be widened too
-expectError(propEq(2)('literals')(obj));
-expectError(propEq(2, 'literals')(obj));
-expectError(propEq(2, 'literals', obj));
-
-// manually widened also works
-expectType<boolean>(propEq('A' as string)('literals')(obj));
-expectType<boolean>(propEq('A' as string, 'literals')(obj));
-// only rejects for propEq(val, key, obj), `string` is too wide for 'A' | 'B'
-expectError(propEq('A' as string, 'literals', obj));
-
-// rejects if key is not on obj
-expectError(propEq('A')('literals')({} as Omit<Obj, 'literals'>));
-expectError(propEq('A', 'literals')({} as Omit<Obj, 'literals'>));
-expectError(propEq('A', 'literals', {} as Omit<Obj, 'literals'>));
-
-// rejects empty object literal
-expectError(propEq('A')('literals')({}));
-expectError(propEq('A', 'literals')({}));
-expectError(propEq('A', 'literals', {}));
-
-//
-// unions
-//
-
-// happy path works as expected
-expectType<boolean>(propEq('1')('unions')(obj));
-expectType<boolean>(propEq('1', 'unions')(obj));
-expectType<boolean>(propEq('1', 'unions', obj));
-
-expectType<boolean>(propEq(1)('unions')(obj));
-expectType<boolean>(propEq(1, 'unions')(obj));
-expectType<boolean>(propEq(1, 'unions', obj));
-
-// rejects if typeof val not part of union type
-expectError(propEq(true)('unions')(obj));
-expectError(propEq(true, 'unions')(obj));
-expectError(propEq(true, 'unions', obj));
-
-// rejects if key is not on obj
-expectError(propEq('1')('unions')({} as Omit<Obj, 'unions'>));
-expectError(propEq('1', 'unions')({} as Omit<Obj, 'unions'>));
-expectError(propEq('1', 'unions', {} as Omit<Obj, 'unions'>));
-
-// rejects empty object literal
-expectError(propEq('1')('unions')({}));
-expectError(propEq('1', 'unions')({}));
-expectError(propEq('1', 'unions', {}));
-
-//
-// nullable
-//
-
-// happy path works as expected
-expectType<boolean>(propEq(1)('nullable')(obj));
-expectType<boolean>(propEq(1, 'nullable')(obj));
-expectType<boolean>(propEq(1, 'nullable', obj));
-
-expectType<boolean>(propEq(null)('nullable')(obj));
-expectType<boolean>(propEq(null, 'nullable')(obj));
-expectType<boolean>(propEq(null, 'nullable', obj));
-
-expectType<boolean>(propEq(undefined)('nullable')(obj));
-expectType<boolean>(propEq(undefined, 'nullable')(obj));
-expectType<boolean>(propEq(undefined, 'nullable', obj));
-
-// rejects if typeof val not part of union type
-expectError(propEq(true)('nullable')(obj));
-expectError(propEq(true, 'nullable')(obj));
-expectError(propEq(true, 'nullable', obj));
-
-// rejects if key is not on obj
-expectError(propEq(1)('nullable')({} as Omit<Obj, 'nullable'>));
-expectError(propEq(1, 'nullable')({} as Omit<Obj, 'nullable'>));
-expectError(propEq(1, 'nullable', {} as Omit<Obj, 'nullable'>));
-
-// rejects empty object literal
-expectError(propEq(1)('nullable')({}));
-expectError(propEq(1, 'nullable')({}));
-expectError(propEq(1, 'nullable', {}));
-
-//
-// optional
-//
-
-// happy path works as expected
-expectType<boolean>(propEq(1)('optional')(obj));
-expectType<boolean>(propEq(1, 'optional')(obj));
-expectType<boolean>(propEq(1, 'optional', obj));
-
-expectType<boolean>(propEq(undefined)('optional')(obj));
-expectType<boolean>(propEq(undefined, 'optional')(obj));
-expectType<boolean>(propEq(undefined, 'optional', obj));
-
-// `null` produces error for `optional`. this is expected because typescript strictNullCheck `null !== undefined`
-expectError(propEq(null)('optional')(obj));
-expectError(propEq(null, 'optional')(obj));
-expectError(propEq(null, 'optional', obj));
-
-// rejects if typeof val not part of union type
-expectError(propEq(true)('optional')(obj));
-expectError(propEq(true, 'optional')(obj));
-expectError(propEq(true, 'optional', obj));
-
-// rejects if key is not on obj
-expectError(propEq(1)('optional')({} as Omit<Obj, 'optional'>));
-expectError(propEq(1, 'optional')({} as Omit<Obj, 'optional'>));
-expectError(propEq(1, 'optional', {} as Omit<Obj, 'optional'>));
-
-// rejects empty object literal literal
-expectError(propEq(1)('optional')({}));
-expectError(propEq(1, 'optional')({}));
-expectError(propEq(1, 'optional', {}));
-
-//
-// other non-happy paths
-//
-
-// rejects unknown key
-expectError(propEq(1)('whatever')(obj));
-expectError(propEq(1, 'whatever')(obj));
-expectError(propEq(1, 'whatever', obj));
-
-// rejects unknown key on emptyu object literal
-expectError(propEq(1)('whatever')({}));
-expectError(propEq(1, 'whatever')({}));
-expectError(propEq(1, 'whatever', {}));
+// propEq(val, name)(obj)
+expectType<boolean>(propEq('foo', 'union')({} as Obj));
+// 'nope' is inferred as 'string' here.
+expectType<boolean>(propEq('nope', 'union')({} as Obj));
+// completely different type fails
+expectError(propEq(2, 'union')({} as Obj));

--- a/types/allPass.d.ts
+++ b/types/allPass.d.ts
@@ -1,24 +1,11 @@
-// narrowing
 export function allPass<T, TF1 extends T, TF2 extends T>(
-  predicates: [
-    (a: T) => a is TF1,
-    (a: T) => a is TF2
-  ]
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2]
 ): (a: T) => a is TF1 & TF2;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  predicates: [
-    (a: T) => a is TF1,
-    (a: T) => a is TF2,
-    (a: T) => a is TF3
-  ],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
 ): (a: T) => a is TF1 & TF2 & TF3;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T>(
-  predicates: [
-    (a: T) => a is TF1,
-    (a: T) => a is TF2,
-    (a: T) => a is TF3,
-    (a: T) => a is TF4
-  ],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3, (a: T) => a is TF4],
 ): (a: T) => a is TF1 & TF2 & TF3 & TF4;
 export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T>(
   predicates: [
@@ -39,46 +26,4 @@ export function allPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 exte
     (a: T) => a is TF6
   ],
 ): (a: T) => a is TF1 & TF2 & TF3 & TF4 & TF5 & TF6;
-// regular
-export function allPass<T1, T2>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean
-  ],
-): (a: T1 & T2) => boolean;
-export function allPass<T1, T2, T3>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean,
-    (a: T3) => boolean
-  ],
-): (a: T1 & T2 & T3) => boolean;
-export function allPass<T1, T2, T3, T4>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean,
-    (a: T3) => boolean,
-    (a: T4) => boolean
-  ],
-): (a: T1 & T2 & T3 & T4) => boolean;
-export function allPass<T1, T2, T3, T4, T5>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean,
-    (a: T3) => boolean,
-    (a: T4) => boolean,
-    (a: T5) => boolean
-  ],
-): (a: T1 & T2 & T3 & T4 & T5) => boolean;
-export function allPass<T1, T2, T3, T4, T5, T6>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean,
-    (a: T3) => boolean,
-    (a: T4) => boolean,
-    (a: T5) => boolean,
-    (a: T6) => boolean
-  ],
-): (a: T1 & T2 & T3 & T4 & T5 & T6) => boolean;
-// catch-all
 export function allPass<F extends (...args: any[]) => boolean>(predicates: readonly F[]): F;

--- a/types/anyPass.d.ts
+++ b/types/anyPass.d.ts
@@ -1,24 +1,14 @@
-// narrowing
 export function anyPass<T, TF1 extends T, TF2 extends T>(
-  predicates: [
-    (a: T) => a is TF1,
-    (a: T) => a is TF2
-  ],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2],
 ): (a: T) => a is TF1 | TF2;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
-  predicates: [
-    (a: T) => a is TF1,
-    (a: T) => a is TF2,
-    (a: T) => a is TF3
-  ],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
+): (a: T) => a is TF1 | TF2 | TF3;
+export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T>(
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3],
 ): (a: T) => a is TF1 | TF2 | TF3;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T>(
-  predicates: [
-    (a: T) => a is TF1,
-    (a: T) => a is TF2,
-    (a: T) => a is TF3,
-    (a: T) => a is TF4
-  ],
+  predicates: [(a: T) => a is TF1, (a: T) => a is TF2, (a: T) => a is TF3, (a: T) => a is TF4],
 ): (a: T) => a is TF1 | TF2 | TF3 | TF4;
 export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 extends T, TF5 extends T>(
   predicates: [
@@ -39,46 +29,4 @@ export function anyPass<T, TF1 extends T, TF2 extends T, TF3 extends T, TF4 exte
     (a: T) => a is TF6
   ],
 ): (a: T) => a is TF1 | TF2 | TF3 | TF4 | TF5 | TF6;
-// regular
-export function anyPass<T1, T2>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean
-  ],
-): (a: T1 & T2) => boolean;
-export function anyPass<T1, T2, T3>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean,
-    (a: T3) => boolean
-  ],
-): (a: T1 & T2 & T3) => boolean;
-export function anyPass<T1, T2, T3, T4>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean,
-    (a: T3) => boolean,
-    (a: T4) => boolean
-  ],
-): (a: T1 & T2 & T3 & T4) => boolean;
-export function anyPass<T1, T2, T3, T4, T5>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean,
-    (a: T3) => boolean,
-    (a: T4) => boolean,
-    (a: T5) => boolean
-  ],
-): (a: T1 & T2 & T3 & T4 & T5) => boolean;
-export function anyPass<T1, T2, T3, T4, T5, T6>(
-  predicates: [
-    (a: T1) => boolean,
-    (a: T2) => boolean,
-    (a: T3) => boolean,
-    (a: T4) => boolean,
-    (a: T5) => boolean,
-    (a: T6) => boolean
-  ],
-): (a: T1 & T2 & T3 & T4 & T5 & T6) => boolean;
-// catch-all
 export function anyPass<F extends (...args: any[]) => boolean>(predicates: readonly F[]): F;

--- a/types/propEq.d.ts
+++ b/types/propEq.d.ts
@@ -1,13 +1,6 @@
-import { WidenLiterals } from './util/tools';
-
-// propEq(val)
 export function propEq<T>(val: T): {
-  // propEq(val)(name)(obj)
-  <K extends PropertyKey>(name: K): <U extends Partial<Record<K, any>>>(obj: Required<U> extends Record<K, any> ? T extends WidenLiterals<U[K]> ? U : never : never) => boolean;
-  // propEq(val)(name, obj)
-  <K extends PropertyKey, U extends Partial<Record<K, any>>>(name: K, obj: Required<U> extends Record<K, any> ? T extends WidenLiterals<U[K]> ? U : never : never): boolean;
+  <K extends PropertyKey>(name: K): (obj: Record<K, T>) => boolean;
+  <K extends PropertyKey>(name: K, obj: Record<K, T>): boolean;
 };
-// propEq(val, name)(obj)
-export function propEq<T, K extends PropertyKey>(val: T, name: K): <U extends Partial<Record<K, any>>>(obj: Required<U> extends Record<K, any> ? T extends WidenLiterals<U[K]> ? U : never : never) => boolean;
-// propEq(val, name, obj)
+export function propEq<T, K extends PropertyKey>(val: T, name: K): (obj: Record<K, T>) => boolean;
 export function propEq<K extends keyof U, U>(val: U[K], name: K, obj: U): boolean;


### PR DESCRIPTION
Reverts ramda/types#74

@Nemo108 In my MR out on , this [comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68695/files#r1498384115) pointed out a test that I had [commented out](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68695/files#diff-a096ac4443ad8895567b9b66307ae20048ba4ff89d80098b646ef22fa1e47971R38-R40). I had the intention of coming back to, but forgot (human error).

That test is this:
```
    const coll = [{ type: "BUY" }, { type: "SELL" }, { type: "BUY" }];
    const isBuy = R.propEq("BUY", "type");
    R.filter(isBuy, coll); // => [{ type: 'BUY' }, { type: 'BUY' }]
```
You get an error on `isBuy` being passed to `R.filter`:
<details>
<summary>Expand to see error</summary>
```
No overload matches this call.
  Overload 1 of 5, '(pred: (val: { type: string; }) => val is { type: string; }, list: readonly { type: string; }[]): { type: string; }[]', gave the following error.
    Argument of type '<U extends Partial<Record<"type", any>>>(obj: Required<U> extends Record<"type", any> ? string extends WidenLiterals<U["type"]> ? U : never : never) => boolean' is not assignable to parameter of type '(val: { type: string; }) => val is { type: string; }'.
      Signature '(obj: { type: string; }): boolean' must be a type predicate.
  Overload 2 of 5, '(pred: (val: unknown) => val is unknown, dict: Record<string, unknown>): Record<string, unknown>', gave the following error.
    Argument of type '<U extends Partial<Record<"type", any>>>(obj: Required<U> extends Record<"type", any> ? string extends WidenLiterals<U["type"]> ? U : never : never) => boolean' is not assignable to parameter of type '(val: unknown) => val is unknown'.
      Types of parameters 'obj' and 'val' are incompatible.
        Type 'unknown' is not assignable to type 'Partial<Record<"type", any>>'.
  Overload 3 of 5, '(pred: (value: unknown) => boolean, collection: { type: string; }[]): { type: string; }[]', gave the following error.
    Argument of type '<U extends Partial<Record<"type", any>>>(obj: Required<U> extends Record<"type", any> ? string extends WidenLiterals<U["type"]> ? U : never : never) => boolean' is not assignable to parameter of type '(value: unknown) => boolean'.
      Types of parameters 'obj' and 'value' are incompatible.
        Type 'unknown' is not assignable to type 'Partial<Record<"type", any>>'.ts(2769)
```
</details>
It's very long and hard to understand. tl;dr is that the function signature returned by `R.propEq("BUY", "type")` is not compatible as a first argument for `R.filter()`. Or in other words, typescript does it see it as a `(pred: (val) => boolean)`

I'm pretty sure it's because of how we have the turnary and the `: never`. The fact that that function's first argument _could_ be the bottom type `never`, it will never be compatible with `R.filter()` or any function that is looking for a a function predicate such at that.

This means that https://github.com/ramda/types/pull/74 breaks existing behavior in a net-negative way. While it did solve a lot of the defined issues called out, I can't keep this as is.

This sucks, a lot. But I must revert it. I can't move forward if it's going to break consumer's existing code negatively like this.