### PR TITLE
fix(forEach) Remove forEach second generic on root function

### DIFF
--- a/test/forEach.test.ts
+++ b/test/forEach.test.ts
@@ -14,3 +14,8 @@ expectType<readonly number[]>(forEach(__, arrRO)(noop));
 
 expectType<number[]>(forEach(noop)(arr));
 expectType<readonly number[]>(forEach(noop)(arrRO));
+
+// inline arrow functions should get type inferred
+let someMutVar: number;
+expectType<number[]>(forEach(num => { someMutVar + num; }, arr));
+expectType<readonly number[]>(forEach(num => { someMutVar + num; }, arrRO));

--- a/types/forEach.d.ts
+++ b/types/forEach.d.ts
@@ -1,5 +1,5 @@
 import { Placeholder } from './util/tools';
 
 export function forEach<T>(fn: (x: T) => void): <U extends readonly T[]>(list: U) => U;
-export function forEach<U extends readonly any[] = readonly any[]>(__: Placeholder, list: U): (fn: (x: U extends readonly (infer T)[] ? T : never) => void) => U;
-export function forEach<T, U extends readonly T[] = readonly T[]>(fn: (x: T) => void, list: U): U;
+export function forEach<U extends readonly any[]>(__: Placeholder, list: U): (fn: (x: U extends readonly (infer T)[] ? T : never) => void) => U;
+export function forEach<U extends readonly any[]>(fn: (x: U extends readonly (infer T)[] ? T : never) => void, list: U): U;

--- a/types/forEach.d.ts
+++ b/types/forEach.d.ts
@@ -3,3 +3,5 @@ import { Placeholder } from './util/tools';
 export function forEach<T>(fn: (x: T) => void): <U extends readonly T[]>(list: U) => U;
 export function forEach<U extends readonly any[]>(__: Placeholder, list: U): (fn: (x: U extends readonly (infer T)[] ? T : never) => void) => U;
 export function forEach<U extends readonly any[]>(fn: (x: U extends readonly (infer T)[] ? T : never) => void, list: U): U;
+// this last one is for addIndex(forEach)
+export function forEach<T>(fn: (item: T) => void, list: readonly T[]): T[];


### PR DESCRIPTION
Fixes https://github.com/ramda/types/issues/112

This makes the root `forEach` function go from 2 generics to 1 generic, which is breaking, but it can't be helped. The inference of an inline function is far more important. Besides, it's rare that anyone should have to set the generic manually.