### PR TITLE
Fix: ts4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,16 @@
     "ts4"
   ],
   "types": "./es/index.d.ts",
+  "typesVersions": {
+    "<5": {
+      "index.d.ts": [
+        "ts4/index.d.ts"
+      ],
+      "*": [
+        "ts4/*"
+      ]
+    }
+  },
   "scripts": {
     "build": "npm run build:types && npm run build:ts4",
     "build:types": "node scripts/buildTypes.mjs",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
   "types": "./es/index.d.ts",
   "typesVersions": {
     "<5": {
-      "index.d.ts": [
-        "ts4/index.d.ts"
-      ],
       "*": [
         "ts4/*"
       ]


### PR DESCRIPTION
I can't believe I fucked this up: https://github.com/ramda/types/pull/80/commits/8f80f42f2fd93ed5d3727a2d08b8e109289bd737#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519

While testing to see if this worked
```
  "typesVersions": {
    "<5": {
      "index.d.ts": [
        "ts4/index.d.ts"
      ],
      "*": [
        "ts4/*"
      ]
    }
  },
```

I was adding/removing it locally while testing it against a local repo with typescript@4. It worked as expected, and then, with it still removed, committed it 🤦

This will re-fix ts4 support

## How I tested this

* Pull this repo: https://github.com/Harris-Miller/ramda-ts4-test and `npm ci`
* It's a simple project that uses the 2 ts@5 only functions `pick` and `omit`
* The project has ts@4 installed, so `npm run build` will have typescript errors
* Pull down this branch, `npm run build`
* Using [yalc](https://www.npmjs.com/package/yalc), do `yalc publish`
* back over in ramda-ts4-test do `yalc link types-ramda`
* do `npm run build` again see the type errors are gone