### PR TITLE
`type()` can return `BigInt`

### DIFF
--- a/types/type.d.ts
+++ b/types/type.d.ts
@@ -11,4 +11,5 @@ export function type(val: any):
 | 'Undefined'
 | 'Symbol'
 | 'Error'
-| 'Date';
+| 'Date'
+| 'BigInt';


### PR DESCRIPTION
According to the [implementation](https://github.com/ramda/ramda/blob/master/source/type.js):

```ts
Object.prototype.toString.call(BigInt(123)).slice(8, -1) // "BigInt"
```