### PR TITLE
fix (merge funcs) optimize when both sides are same type

### DIFF
--- a/test/mergeDeepLeft.test.ts
+++ b/test/mergeDeepLeft.test.ts
@@ -1,0 +1,25 @@
+import { expectType } from 'tsd';
+import { mergeDeepLeft } from '../es';
+
+const foo = { foo: 'foo', inner: { a: 1 } };
+const bar = { bar: 'bar', inner: { b: 5 } };
+const foo2 = { foo: 2 };
+
+expectType<{ foo: string; bar: string; inner: { a: number; b: number } }>(mergeDeepLeft(foo, bar));
+expectType<{ foo: string; inner: { a: number } }>(mergeDeepLeft(foo, foo2));
+expectType<{ foo: number; inner: { a: number } }>(mergeDeepLeft(foo2, foo));
+
+type TestType = {
+  foo: string;
+  bar: string;
+  inner: { a: number; b: number }
+};
+
+const obj1 = {} as TestType;
+const obj2 = {} as TestType;
+
+expectType<TestType>(mergeDeepLeft(obj1, obj2));
+expectType<TestType>(mergeDeepLeft(obj2, obj1));
+
+expectType<TestType>(mergeDeepLeft(obj1, { foo: '', bar: '', inner: { a: 1, b: 2 } }));
+expectType<TestType>(mergeDeepLeft({ foo: '', bar: '', inner: { a: 1, b: 2 } }, obj2));

--- a/test/mergeDeepRight.test.ts
+++ b/test/mergeDeepRight.test.ts
@@ -1,0 +1,25 @@
+import { expectType } from 'tsd';
+import { mergeDeepRight } from '../es';
+
+const foo = { foo: 'foo', inner: { a: 1 } };
+const bar = { bar: 'bar', inner: { b: 5 } };
+const foo2 = { foo: 2 };
+
+expectType<{ foo: string; bar: string; inner: { a: number; b: number } }>(mergeDeepRight(foo, bar));
+expectType<{ foo: string; inner: { a: number } }>(mergeDeepRight(foo2, foo));
+expectType<{ foo: number; inner: { a: number } }>(mergeDeepRight(foo, foo2));
+
+type TestType = {
+  foo: string;
+  bar: string;
+  inner: { a: number; b: number }
+};
+
+const obj1 = {} as TestType;
+const obj2 = {} as TestType;
+
+expectType<TestType>(mergeDeepRight(obj1, obj2));
+expectType<TestType>(mergeDeepRight(obj2, obj1));
+
+expectType<TestType>(mergeDeepRight(obj1, { foo: '', bar: '', inner: { a: 1, b: 2 } }));
+expectType<TestType>(mergeDeepRight({ foo: '', bar: '', inner: { a: 1, b: 2 } }, obj2));

--- a/test/mergeLeft.test.ts
+++ b/test/mergeLeft.test.ts
@@ -7,3 +7,17 @@ const foo2 = { foo: 2 };
 
 expectType<{ foo: string; bar: string; }>(mergeLeft(foo, bar));
 expectType<{ foo: string; }>(mergeLeft(foo, foo2));
+
+type TestType = {
+  foo: string;
+  bar: string;
+};
+
+const obj1 = {} as TestType;
+const obj2 = {} as TestType;
+
+expectType<TestType>(mergeLeft(obj1, obj2));
+expectType<TestType>(mergeLeft(obj2, obj1));
+
+expectType<TestType>(mergeLeft(obj1, { foo: '', bar: ''}));
+expectType<TestType>(mergeLeft({ foo: '', bar: ''}, obj2));

--- a/test/mergeRight.test.ts
+++ b/test/mergeRight.test.ts
@@ -7,3 +7,17 @@ const foo2 = { foo: 2 };
 
 expectType<{ foo: string; bar: string; }>(mergeRight(foo, bar));
 expectType<{ foo: number; }>(mergeRight(foo, foo2));
+
+type TestType = {
+  foo: string;
+  bar: string;
+};
+
+const obj1 = {} as TestType;
+const obj2 = {} as TestType;
+
+expectType<TestType>(mergeRight(obj1, obj2));
+expectType<TestType>(mergeRight(obj2, obj1));
+
+expectType<TestType>(mergeRight(obj1, { foo: '', bar: ''}));
+expectType<TestType>(mergeRight({ foo: '', bar: ''}, obj2));

--- a/types/mergeDeepLeft.d.ts
+++ b/types/mergeDeepLeft.d.ts
@@ -1,4 +1,6 @@
 import * as _ from 'ts-toolbelt';
 
+export function mergeDeepLeft<U extends object>(l: U): (r: U) => U;
 export function mergeDeepLeft<L extends object>(l: L): <R extends object>(r: R) => _.O.Assign<R, [L], 'deep'>;
+export function mergeDeepLeft<U extends object>(l: U, r: U): U;
 export function mergeDeepLeft<L extends object, R extends object>(l: L, r: R): _.O.Assign<R, [L], 'deep'>;

--- a/types/mergeDeepRight.d.ts
+++ b/types/mergeDeepRight.d.ts
@@ -1,4 +1,6 @@
 import * as _ from 'ts-toolbelt';
 
+export function mergeDeepRight<U extends object>(l: U): (r: U) => U;
 export function mergeDeepRight<L extends object>(l: L): <R extends object>(r: R) => _.O.Assign<L, [R], 'deep'>;
+export function mergeDeepRight<U extends object>(l: U, r: U): U;
 export function mergeDeepRight<L extends object, R extends object>(l: L, r: R): _.O.Assign<L, [R], 'deep'>;

--- a/types/mergeLeft.d.ts
+++ b/types/mergeLeft.d.ts
@@ -1,5 +1,7 @@
 import * as _ from 'ts-toolbelt';
 
 // Note: ramda `mergeLeft` uses `Object.assign` in code, so we need to use `O.Assign` here, and not `O.Merge`
+export function mergeLeft<U extends object>(l: U): (r: U) => U;
 export function mergeLeft<L extends object>(l: L): <R extends object>(r: R) => _.O.Assign<R, [L], 'flat'>;
+export function mergeLeft<U extends object>(l: U, r: U): U;
 export function mergeLeft<L extends object, R extends object>(l: L, r: R): _.O.Assign<R, [L], 'flat'>;

--- a/types/mergeRight.d.ts
+++ b/types/mergeRight.d.ts
@@ -1,5 +1,7 @@
 import * as _ from 'ts-toolbelt';
 
 // Note: ramda `mergeLeft` uses `Object.assign` in code, so we need to use `O.Assign` here, and not `O.Merge`
+export function mergeRight<U extends object>(l: U): (r: U) => U;
 export function mergeRight<L extends object>(l: L): <R extends object>(r: R) => _.O.Assign<L, [R], 'flat'>;
+export function mergeRight<U extends object>(l: U, r: U): U;
 export function mergeRight<L extends object, R extends object>(l: L, r: R): _.O.Assign<L, [R], 'flat'>;


### PR DESCRIPTION
fixes https://github.com/ramda/types/issues/128

Adds in an optimization for `mergeLeft`, `mergeRight`, `mergeDeepLeft`, and `mergeDeepRight` where if both objects `l` and `r` are of the same type, that type is what is returned. This is cleaner as general typings go, as well as preventing unnecessary calculations by the typescript compiler