### PR TITLE
add bigint to the Ord type

### DIFF
--- a/test/max.test.ts
+++ b/test/max.test.ts
@@ -14,6 +14,7 @@ expectType<number>(max(1 as number, 2 as number));
 expectType<string>(max('a' as string, 'b' as string));
 expectType<boolean>(max(true as boolean, false as boolean));
 expectType<Date>(max(new Date(Date.now() - 1), new Date(Date.now())));
+expectType<bigint>(max(1n as bigint, 2n as bigint));
 
 // curried
 expectType<(b: number) => number>(max(a));

--- a/test/maxBy.test.ts
+++ b/test/maxBy.test.ts
@@ -6,6 +6,7 @@ type Obj = {
   str: string;
   date: Date;
   bool: boolean;
+  bigint: bigint;
 };
 
 // please note how literals work in this situation
@@ -20,6 +21,7 @@ expectType<number>(maxBy(Math.abs, 1 as number, 2 as number));
 expectType<Obj>(maxBy(prop('str'), {} as Obj, {} as Obj));
 expectType<Obj>(maxBy(prop('bool'), {} as Obj, {} as Obj));
 expectType<Obj>(maxBy(prop('date'), {} as Obj, {} as Obj));
+expectType<Obj>(maxBy(prop('bigint'), {} as Obj, {} as Obj));
 
 // Placeholder
 // expectType<number>(max(__, a, b)(fn));

--- a/test/min.test.ts
+++ b/test/min.test.ts
@@ -14,6 +14,7 @@ expectType<number>(min(1 as number, 2 as number));
 expectType<string>(min('a' as string, 'b' as string));
 expectType<boolean>(min(true as boolean, false as boolean));
 expectType<Date>(min(new Date(Date.now() - 1), new Date(Date.now())));
+expectType<bigint>(min(1n as bigint, 2n as bigint));
 
 // curried
 expectType<(b: number) => number>(min(a));

--- a/test/minBy.test.ts
+++ b/test/minBy.test.ts
@@ -6,6 +6,7 @@ type Obj = {
   str: string;
   date: Date;
   bool: boolean;
+  bigint: bigint;
 };
 
 // please note how literals work in this situation
@@ -20,6 +21,7 @@ expectType<number>(minBy(Math.abs, 1 as number, 2 as number));
 expectType<Obj>(minBy(prop('str'), {} as Obj, {} as Obj));
 expectType<Obj>(minBy(prop('bool'), {} as Obj, {} as Obj));
 expectType<Obj>(minBy(prop('date'), {} as Obj, {} as Obj));
+expectType<Obj>(minBy(prop('bigint'), {} as Obj, {} as Obj));
 
 // Placeholder
 // expectType<number>(max(__, b)(a));

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -324,7 +324,7 @@ export type ObjPred<T = unknown> = (value: any, key: unknown extends T ? string 
 /**
  * Values that can be compared using the relational operators `<`/`<=`/`>`/`>=`
  */
-export type Ord = number | string | boolean | Date;
+export type Ord = number | string | boolean | Date | bigint;
 
 /**
  * `a` is less than `b`


### PR DESCRIPTION
bigint supports all the regular comparison operators, works fine with Ramda, it's just not supported in these types at the moment.