### PR TITLE
(new) renameKeys and 0.31.0 bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['20', '18', '16']
+        node: ['24', '22', '20']
     name: Node ${{ matrix.node }}
     steps:
       - name: Checkout repository

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "types-ramda",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "types-ramda",
-      "version": "0.30.1",
+      "version": "0.31.0",
       "license": "MIT",
       "dependencies": {
         "ts-toolbelt": "^9.6.0"
@@ -17,7 +17,7 @@
         "dox": "^1.0.0",
         "eslint": "^8.50.0",
         "eslint-plugin-import": "^2.28.1",
-        "ramda": "^0.30.1",
+        "ramda": "^0.31.3",
         "rimraf": "^5.0.5",
         "tsd": "^0.31.0",
         "typescript": "^5.2.2",
@@ -3115,10 +3115,11 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.31.3.tgz",
+      "integrity": "sha512-xKADKRNnqmDdX59PPKLm3gGmk1ZgNnj3k7DryqWwkamp4TJ6B36DdpyKEQ0EoEYmH2R62bV4Q+S0ym2z8N2f3Q==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -6263,9 +6264,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.31.3.tgz",
+      "integrity": "sha512-xKADKRNnqmDdX59PPKLm3gGmk1ZgNnj3k7DryqWwkamp4TJ6B36DdpyKEQ0EoEYmH2R62bV4Q+S0ym2z8N2f3Q==",
       "dev": true
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "types-ramda",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Dedicated types library for ramda",
   "author": "Harris Miller <harrismillerconsulting@gmail.com>",
   "contributors": [
@@ -67,7 +67,7 @@
     "dox": "^1.0.0",
     "eslint": "^8.50.0",
     "eslint-plugin-import": "^2.28.1",
-    "ramda": "^0.30.1",
+    "ramda": "^0.31.3",
     "rimraf": "^5.0.5",
     "tsd": "^0.31.0",
     "typescript": "^5.2.2",

--- a/test/renameKeys.test.ts
+++ b/test/renameKeys.test.ts
@@ -1,0 +1,19 @@
+import { expectAssignable, expectType } from 'tsd';
+
+import { __, renameKeys } from '../es';
+
+expectType<{ bar: number; other: string }>(renameKeys({ foo: 'bar' })({ foo: 123, other: 'abc' }));
+expectType<{ foo: number; blah: string }>(renameKeys({ other: 'blah' })({ foo: 123, other: 'abc' }));
+
+expectType<{ bar: number; other: string }>(renameKeys(__, { foo: 123, other: 'abc' })({ foo: 'bar' }));
+expectType<{ foo: number; blah: string }>(renameKeys(__, { foo: 123, other: 'abc' })({ other: 'blah' }));
+
+expectType<{ bar: number; other: string }>(renameKeys({ foo: 'bar' }, { foo: 123, other: 'abc' }));
+expectType<{ foo: number; blah: string }>(renameKeys({ other: 'blah' }, { foo: 123, other: 'abc' }));
+
+const nonConstObj = { foo: 'bar' };
+
+const what = renameKeys(nonConstObj, { foo: 123, other: 'abc' });
+//    ^?
+// @ts-expect-error - I have no idea why declaring the type throws an error, but it can be calculated above
+expectAssignable<{ [x: string]: number; other: string; }>(what);

--- a/types/renameKeys.d.ts
+++ b/types/renameKeys.d.ts
@@ -1,0 +1,8 @@
+import { Placeholder, Prettify, Remap } from './util/tools';
+
+// renameKeys(mapping)(obj)
+export function renameKeys<const U extends Record<PropertyKey, string>>(mapping: U): <T extends Record<keyof U, unknown>>(obj: T) => Prettify<Omit<T, keyof U> & Remap<T, U>>;
+// renameKeys(__, obj)(mapping)
+export function renameKeys<T>(__: Placeholder, obj: T): <const U extends Partial<Record<keyof T, string>>>(mapping: U) => Prettify<Omit<T, keyof U> & Remap<T, U>>;
+// renameKeys(mapping, obj)
+export function renameKeys<T, const U extends Partial<Record<keyof T, string>>>(mapping: U, obj: T): Prettify<Omit<T, keyof U> & Remap<T, U>>;

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -520,3 +520,28 @@ export type NonEmptyArray<T> = [T, ...T[]];
  * <created by @harris-miller>
  */
 export type ReadonlyNonEmptyArray<T> = readonly [T, ...T[]];
+
+/**
+ * Prettify type into an object literal
+ * <created by @harris-miller>
+ */
+export type Prettify<T> = {[KeyType in keyof T]: T[KeyType]} & {};
+
+type TuplesFromObject<T> = {
+  [P in keyof T]: [P, T[P]];
+}[keyof T];
+
+type GetKeyByValue<T, V> =
+  TuplesFromObject<T> extends infer TT
+    ? TT extends [infer P, V]
+      ? P
+      : never
+    : never;
+
+/**
+ * Remap keys of one object to the values of mapping object
+ * <created by @RobinTail>
+ */
+export type Remap<T, U extends { [P in keyof T]?: string }> = {
+  [P in NonNullable<U[keyof U]>]: T[GetKeyByValue<U, P>];
+};


### PR DESCRIPTION
Moved _just_ the implementation for `renameKeys` over from https://github.com/ramda/types/pull/140 for release of 0.31.0. Bumping the version in `package.json` will eventually make it down to `main` after I merge then release from my local