### PR TITLE
fromPairs() accepts readonly tuples

### DIFF
--- a/types/fromPairs.d.ts
+++ b/types/fromPairs.d.ts
@@ -1,3 +1,3 @@
 export function fromPairs<K extends PropertyKey, V>(
-  pairs: readonly [K, V][]
+  pairs: readonly (readonly [K, V])[]
 ): { [P in K]: V };


### PR DESCRIPTION
Resolves [DefinitelyTyped discussion: _[ramda] fromPairs() does not accept readonly pairs_](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/73479)

_I can copy/paste here the issue I posted there if you wish to..._