### PR TITLE
Fix: ts4 compat version of renameKeys

### DIFF
--- a/types-ts4/renameKeys.d.ts
+++ b/types-ts4/renameKeys.d.ts
@@ -1,0 +1,8 @@
+import { Placeholder, Prettify, Remap } from './util/tools';
+
+// renameKeys(mapping)(obj)
+export function renameKeys<U extends Record<PropertyKey, string>>(mapping: U): <T extends Record<keyof U, unknown>>(obj: T) => Prettify<Omit<T, keyof U> & Remap<T, U>>;
+// renameKeys(__, obj)(mapping)
+export function renameKeys<T>(__: Placeholder, obj: T): <U extends Partial<Record<keyof T, string>>>(mapping: U) => Prettify<Omit<T, keyof U> & Remap<T, U>>;
+// renameKeys(mapping, obj)
+export function renameKeys<T, U extends Partial<Record<keyof T, string>>>(mapping: U, obj: T): Prettify<Omit<T, keyof U> & Remap<T, U>>;


### PR DESCRIPTION
`const` in generics doesn't work in TS4. I missed that when updating the typing for `renameKeys` a while back. This MR adds a ts4 compat version, similar to `omit` and `pick`